### PR TITLE
GUI: update command line instructions in README.md

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -12,11 +12,11 @@ conda activate gui
 
 3. Run the GUI via web browser interface:
 ```console
-python app.py --port 1234
+python app.py --port 1234 --experiment /path/to/experimental_data/experimental_data.csv --simulation /path/to/simulation_data/simulation_data.csv --model /path/to/ml/NN_training/base_simulation_model_with_transformers_calibration.yml
 ```
 Alternatively, you can also run the GUI as a desktop application:
 ```console
-python app.py --app
+python app.py --app --experiment /path/to/experimental_data/experimental_data.csv --simulation /path/to/simulation_data/simulation_data.csv --model /path/to/ml/NN_training/base_simulation_model_with_transformers_calibration.yml
 ```
 If you run the GUI as a desktop application, make sure to set the following environment variable first:
 ```console


### PR DESCRIPTION
Adding missing command line arguments in the instructions on how to run the GUI without the container.