### PR TITLE
Change name of the mean wavelength variable

### DIFF
--- a/config/variables.yml
+++ b/config/variables.yml
@@ -41,5 +41,5 @@ acave:
 
   output_variables:
     output1:
-      name: "kHz_thorlab_spectrometer mean_wavelength"
+      name: "kHz_ThorlabsSpec MeanWavelength"
       type: scalar


### PR DESCRIPTION
I changed this in the MongoDB database, to match the exact name used in the BELLA experiment