### PR TITLE
GUI: Rename 'IFE Superfacility' to 'BELLA Superfacility'

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -19,7 +19,6 @@ from utils import read_variables, metadata_match, load_database, plot
 # Initialize experiment
 # -----------------------------------------------------------------------------
 
-state.trame_title = "IFE Superfacility"
 state.experiment = "ip2"
 
 # -----------------------------------------------------------------------------
@@ -220,7 +219,7 @@ reload()
 
 # main page content
 with SinglePageWithDrawerLayout(server) as layout:
-    layout.title.set_text(state.trame_title)
+    layout.title.set_text("BELLA Superfacility")
 
     # add toolbar components
     with layout.toolbar:


### PR DESCRIPTION
I propose to change the title displayed in the GUI. In my opinion, "BELLA Superfacility" seems more accurate name than "IFE Superfacility" at this point.