### PR TITLE
[WIP] GUI: Refactor Functions to Load Database

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -12,7 +12,7 @@ from parameters_manager import ParametersManager
 from objectives_manager import ObjectivesManager
 from nersc import get_sfapi_client, build_sfapi_status, build_sfapi_auth
 from state_manager import server, state, ctrl, init_state
-from utils import read_variables, metadata_match, load_database, plot
+from utils import read_variables, metadata_match, load_database, load_collection, plot
 
 
 # -----------------------------------------------------------------------------
@@ -34,7 +34,11 @@ def reload(**kwargs):
     # initialize state after experiment selection
     init_state()
     # initialize database
-    config, exp_docs, sim_docs = load_database()
+    db = load_database()
+    collection_experiment = load_collection(db, state.experiment)
+    documents_list = list(collection_experiment.find())
+    exp_docs = [doc for doc in documents_list if doc["experiment_flag"] == 1]
+    sim_docs = [doc for doc in documents_list if doc["experiment_flag"] == 0]
     # convert database documents into pandas DataFrames
     state.exp_data = pd.DataFrame(exp_docs).to_json(default_handler=str)
     state.sim_data = pd.DataFrame(sim_docs).to_json(default_handler=str)

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -57,7 +57,6 @@ def metadata_match(config_file, model_file):
 
 def load_database():
     global db
-
     # load database
     db_defaults = {
         "host": "mongodb05.nersc.gov",
@@ -66,15 +65,12 @@ def load_database():
         "auth": "bella_sf",
         "user": "bella_sf_admin",
     }
-
     # read database information from environment variables (if unset, use defaults)
     db_host = os.getenv("SF_DB_HOST", db_defaults["host"])
     db_port = int(os.getenv("SF_DB_PORT", db_defaults["port"]))
     db_name = os.getenv("SF_DB_NAME", db_defaults["name"])
     db_auth = os.getenv("SF_DB_AUTH_SOURCE", db_defaults["auth"])
     db_user = os.getenv("SF_DB_USER", db_defaults["user"])
-    # read database experiment from environment variable (no default provided)
-    db_collection = state.experiment
     # read database password from environment variable (no default provided)
     db_password = os.getenv("SF_DB_PASSWORD")
     if db_password is None:
@@ -95,17 +91,13 @@ def load_database():
             authSource=db_auth,
             directConnection=direct_connection,
         )[db_name]
-    # get collection: ip2, acave, config, ...
+    return db
+
+def load_collection(db, collection_key):
+    # get collection
+    db_collection = collection_key
     collection = db[db_collection]
-    if "config" not in db.list_collection_names():
-        db.create_collection("config")
-    config = db["config"]
-    # retrieve all documents
-    documents = list(collection.find())
-    # separate documents: experimental and simulation
-    exp_docs = [doc for doc in documents if doc["experiment_flag"] == 1]
-    sim_docs = [doc for doc in documents if doc["experiment_flag"] == 0]
-    return (config, exp_docs, sim_docs)
+    return collection
 
 # plot experimental, simulation, and ML data
 def plot(model):


### PR DESCRIPTION
More fine-grained access to database client, collection, etc. will be needed in #81, where the plot callback will need to inspect the database again. Note that the database client cannot be stored in a Trame state variable as is, since it is not serializable.

Before this PR:
- `load_database` returns `config` (a collection), `exp_docs` (a list of documents), `sim_docs` (a list of documents)

After this PR:
- `load_database` returns a database client
- `load_collection` returns a collection for a given keyword (e.g., "config", "ip2", "acave", etc.), which can be then used to extract the documents cursor and query the database 

To-do:
- [x] Merge #84 
- [x] Merge #85 
- [x] Merge #86
- [ ] Test changes in nersc.py