### PR TITLE
GUI: Initialize State Variables Before Listener Registration

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -16,10 +16,11 @@ from utils import read_variables, metadata_match, load_database, plot
 
 
 # -----------------------------------------------------------------------------
-# Initialize experiment
+# Initialize experiment and state variables
 # -----------------------------------------------------------------------------
 
 state.experiment = "ip2"
+init_state()
 
 # -----------------------------------------------------------------------------
 # Callbacks


### PR DESCRIPTION
I'm observing some issues that may have to do with server synchronization. This PR ensures that state variables (the ones currently initialized in the state manager) are initialized before the listeners start watching for changes. Understanding the serve synchronization issues is still work-in-progress, but this should help.