### PR TITLE
GUI: Update Opacity Control Slider

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -167,25 +167,31 @@ def home_route():
                         with vuetify.VCard():
                             with vuetify.VCardTitle("Control: Plots"):
                                 with vuetify.VCardText():
+                                    # create a row for the slider label
                                     with vuetify.VRow():
-                                        with vuetify.VCol():
-                                            pass
-                                    with vuetify.VRow():
-                                        with vuetify.VCol():
-                                            vuetify.VSlider(
-                                                v_model_number=("opacity",),
-                                                change="flushState('opacity')",
-                                                label="Opacity",
-                                                min=0.0,
-                                                max=1.0,
-                                                step=0.1,
-                                                classes="align-center",
-                                                hide_details=True,
-                                                style="width: 100%;",
-                                                thumb_label="always",
-                                                thumb_size=25,
-                                                type="number",
-                                            )
+                                        vuetify.VSubheader("Projected Data Depth")
+                                    # create a row for the slider and text field
+                                    with vuetify.VRow(no_gutters=True):
+                                        with vuetify.VSlider(
+                                            v_model_number=("opacity",),
+                                            change="flushState('opacity')",
+                                            classes="align-center",
+                                            hide_details=True,
+                                            max=1.0,
+                                            min=0.0,
+                                            step=0.025,
+                                        ):
+                                            with vuetify.Template(v_slot_append=True):
+                                                vuetify.VTextField(
+                                                    v_model_number=("opacity",),
+                                                    classes="mt-0 pt-0",
+                                                    density="compact",
+                                                    hide_details=True,
+                                                    readonly=True,
+                                                    single_line=True,
+                                                    style="width: 80px;",
+                                                    type="number",
+                                                )
                                     with vuetify.VRow():
                                         with vuetify.VCol():
                                             with vuetify.VBtn(

--- a/dashboard/state_manager.py
+++ b/dashboard/state_manager.py
@@ -33,7 +33,7 @@ def init_runtime():
     state.exp_data = pd.DataFrame().to_json(default_handler=str)
     state.sim_data = pd.DataFrame().to_json(default_handler=str)
     # opacity
-    state.opacity = 0.1
+    state.opacity = 0.05
     # calibration
     state.is_calibrated = False
     # parameters


### PR DESCRIPTION
Resolve the following subissue listed in #67:

> Could we change the "Opacity" is smaller increments with the slider? (right now, it looks like we can only change it in +/- 0.1 increments) ; also could we change the name to something like "Depth" or "Data depth" (more suggestions welcome), "Depth in projected dimensions"

- [x] Rename `Opacity` as `Projected Data Depth`
- [x] Increase resolution of data depth slider from 0.1 to 0.025
- [x] Reset default data depth at startup to 0.05 (previously 0.1)
- [x] Replace thumb label with text field to the right of the slider

Is `Projected Data Depth` a good name? `Transparency` instead of `Depth` could be an option, too.

Here's an example of the updated dashboard:

![Screenshot from 2025-05-15 11-22-29](https://github.com/user-attachments/assets/fa3ed58a-9bac-4d30-aff2-78b7a083a87f)
