### PR TITLE
Have the opacity go smoothly to 0 when distance=opacity

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -151,7 +151,7 @@ def plot(model):
             df_copy["distance"] = np.sqrt(df_copy["distance"])
             # normalize distance in [0,1] and compute opacity
             df_copy["distance"] = df_copy["distance"] / df_copy["distance"].max()
-            df_copy["opacity"] = np.where(df_copy["distance"] > state.opacity, 0., 1. - df_copy["distance"])
+            df_copy["opacity"] = np.where(df_copy["distance"] > state.opacity, 0., 1. - df_copy["distance"]/state.opacity)
             # filter out data with zero opacity
             df_copy_filtered = df_copy[df_copy["opacity"] != 0.0]
             # scatter plot with opacity


### PR DESCRIPTION
The opacity of the point in the plot should be 0 when distance=opacity, not when distance=1