### PR TITLE
GUI: Update Docker Instructions to Fix Warning

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -81,11 +81,11 @@
 
 2. Run the Docker container from the `dashboard/` folder:
     ```console
-    docker run --network=host -p 27017:27017 -v /etc/localtime:/etc/localtime -v $PWD/../ml:/app/ml -e SF_DB_HOST='127.0.0.1' -e SF_DB_PASSWORD='your_password_here' gui
+    docker run --network=host -v /etc/localtime:/etc/localtime -v $PWD/../ml:/app/ml -e SF_DB_HOST='127.0.0.1' -e SF_DB_PASSWORD='your_password_here' gui
     ```
     For debugging, you can also enter the container without starting the app:
     ```console
-    docker run --network=host -p 27017:27017 -v /etc/localtime:/etc/localtime -v $PWD/../ml:/app/ml -e SF_DB_HOST='127.0.0.1' -e SF_DB_PASSWORD='your_password_here' -it gui bash
+    docker run --network=host -v /etc/localtime:/etc/localtime -v $PWD/../ml:/app/ml -e SF_DB_HOST='127.0.0.1' -e SF_DB_PASSWORD='your_password_here' -it gui bash
     ```
     Note that `-v /etc/localtime:/etc/localtime` is necessary to synchronize the time zone in the container with the host machine.
 


### PR DESCRIPTION
The `-p 27017:27017` option combined with `--network=host` seems to raise this warning:
```
WARNING: Published ports are discarded when using host network mode
```