### PR TITLE
GUI: Update Instructions for Superfacility API Credentials

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -116,7 +116,7 @@ Following the instructions at [docs.nersc.gov/services/sfapi/authentication/#cli
 
 3. Scroll down to the section "Superfacility API Clients" and click "New Client".
 
-4. Enter a client name (e.g., "BELLA Superfacility"), choose "Red" security level, and select "Your IP" from the "IP Presets" menu.
+4. Enter a client name (e.g., "BELLA Superfacility"), choose "Red" security level, and select either "Your IP" or "Spin" from the "IP Presets" menu, depending on whether the key will be used from a local computer or from Spin.
 
 5. Download your private key file (in pem format).
 


### PR DESCRIPTION
Update README instructions to select the correct IP settings when creating a Superfacility API client, depending on whether the key will be used from a local computer or from Spin.