### PR TITLE
GUI: use read-only username and password

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -48,7 +48,7 @@
 2. Set the database settings (read+write):
     ```console
     export SF_DB_HOST='127.0.0.1'
-    export SF_DB_PASSWORD='your_password_here'  # Use SINGLE quotes around the password!
+    export SF_DB_READONLY_PASSWORD='your_password_here'  # Use SINGLE quotes around the password!
     ```
 
 3. For local development, open a separate terminal and keep it open while SSH forwarding the database connection:
@@ -81,11 +81,11 @@
 
 2. Run the Docker container from the `dashboard/` folder:
     ```console
-    docker run --network=host -v /etc/localtime:/etc/localtime -v $PWD/../ml:/app/ml -e SF_DB_HOST='127.0.0.1' -e SF_DB_PASSWORD='your_password_here' gui
+    docker run --network=host -v /etc/localtime:/etc/localtime -v $PWD/../ml:/app/ml -e SF_DB_HOST='127.0.0.1' -e SF_DB_READONLY_PASSWORD='your_password_here' gui
     ```
     For debugging, you can also enter the container without starting the app:
     ```console
-    docker run --network=host -v /etc/localtime:/etc/localtime -v $PWD/../ml:/app/ml -e SF_DB_HOST='127.0.0.1' -e SF_DB_PASSWORD='your_password_here' -it gui bash
+    docker run --network=host -v /etc/localtime:/etc/localtime -v $PWD/../ml:/app/ml -e SF_DB_HOST='127.0.0.1' -e SF_DB_READONLY_PASSWORD='your_password_here' -it gui bash
     ```
     Note that `-v /etc/localtime:/etc/localtime` is necessary to synchronize the time zone in the container with the host machine.
 

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -57,7 +57,7 @@ def load_database():
         "port": 27017,
         "name": "bella_sf",
         "auth": "bella_sf",
-        "user": "bella_sf_admin",
+        "user": "bella_sf_ro",
     }
     # read database information from environment variables (if unset, use defaults)
     db_host = os.getenv("SF_DB_HOST", db_defaults["host"])
@@ -66,9 +66,9 @@ def load_database():
     db_auth = os.getenv("SF_DB_AUTH_SOURCE", db_defaults["auth"])
     db_user = os.getenv("SF_DB_USER", db_defaults["user"])
     # read database password from environment variable (no default provided)
-    db_password = os.getenv("SF_DB_PASSWORD")
+    db_password = os.getenv("SF_DB_READONLY_PASSWORD")
     if db_password is None:
-        raise RuntimeError("Environment variable SF_DB_PASSWORD must be set!")
+        raise RuntimeError("Environment variable SF_DB_READONLY_PASSWORD must be set!")
     # SSH forward?
     if db_host == "localhost" or db_host == "127.0.0.1":
         direct_connection = True


### PR DESCRIPTION
With the way things are implemented currently, we do not need admin privileges to write to the database and can use the read-only username and password instead.