### PR TITLE
GUI: Force stdout, stderr streams to be unbuffered

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -28,7 +28,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 EXPOSE 8080
 
 # Run app.py when the container launches
-CMD ["python", "app.py", "--timeout", "0", "--port", "8080", "--host", "0.0.0.0", "--server"]
+CMD ["python", "-u", "app.py", "--timeout", "0", "--port", "8080", "--host", "0.0.0.0", "--server"]
 # The URL http://0.0.0.0:8080/ is used by the application to indicate that
 # it is listening on all network interfaces inside the container, but you
 # should access it via http://localhost:8080/ from your host machine)

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -59,11 +59,11 @@
 4. Run the GUI from the `dashboard/` folder:
     - Via the web browser interface:
     ```console
-    python app.py --port 8080
+    python -u app.py --port 8080
     ```
     - As a desktop application:
     ```console
-    python app.py --app
+    python -u app.py --app
     ```
     If you run the GUI as a desktop application, make sure to set the following environment variable first:
     ```console


### PR DESCRIPTION
Use the `-u` option to force the stdout and stderr streams to be unbuffered. This allows logging to be visible in real time when running the app from a Docker container, either locally or through Spin - important for debugging issues on Spin.