### PR TITLE
GUI: Bind mount whole repo directory

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -18,17 +18,20 @@ COPY --exclude=*.pem . /app
 RUN conda install -c conda-forge conda-lock \
     && conda-lock install --name gui gui-lock.yml
 
-# Activate env in interactive and CMD use
+# Copy the entrypoint script
 COPY entrypoint.sh /entrypoint.sh
-RUN echo "source entrypoint.sh" >> ~/.bashrc
+
+# Make the entrypoint script executable
 RUN chmod +x /entrypoint.sh
+
+# Define the entrypoint to activate the environment in interactive and CMD use
 ENTRYPOINT ["/entrypoint.sh"]
 
 # Make port 8080 available to the world outside this container
 EXPOSE 8080
 
 # Run app.py when the container launches
-CMD ["python", "-u", "app.py", "--timeout", "0", "--port", "8080", "--host", "0.0.0.0", "--server"]
+CMD ["python", "-u", "dashboard/app.py", "--timeout", "0", "--port", "8080", "--host", "0.0.0.0", "--server"]
 # The URL http://0.0.0.0:8080/ is used by the application to indicate that
 # it is listening on all network interfaces inside the container, but you
 # should access it via http://localhost:8080/ from your host machine)

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -81,11 +81,11 @@
 
 2. Run the Docker container from the `dashboard/` folder:
     ```console
-    docker run --network=host -v /etc/localtime:/etc/localtime -v $PWD/../ml:/app/ml -e SF_DB_HOST='127.0.0.1' -e SF_DB_READONLY_PASSWORD='your_password_here' gui
+    docker run --network=host -v /etc/localtime:/etc/localtime -v $PWD/..:/app -e SF_DB_HOST='127.0.0.1' -e SF_DB_READONLY_PASSWORD='your_password_here' gui
     ```
     For debugging, you can also enter the container without starting the app:
     ```console
-    docker run --network=host -v /etc/localtime:/etc/localtime -v $PWD/../ml:/app/ml -e SF_DB_HOST='127.0.0.1' -e SF_DB_READONLY_PASSWORD='your_password_here' -it gui bash
+    docker run --network=host -v /etc/localtime:/etc/localtime -v $PWD/..:/app -e SF_DB_HOST='127.0.0.1' -e SF_DB_READONLY_PASSWORD='your_password_here' -it gui bash
     ```
     Note that `-v /etc/localtime:/etc/localtime` is necessary to synchronize the time zone in the container with the host machine.
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -62,7 +62,7 @@ def load_data():
     state.sim_data_serialized = pd.DataFrame(sim_docs).to_json(default_handler=str)
 
 def load_config_file():
-    config_dir = os.path.join(os.getcwd(), "config")
+    config_dir = os.path.join(os.getcwd(), "dashboard", "config")
     config_file = os.path.join(config_dir, "variables.yml")
     if not os.path.isfile(config_file):
         raise ValueError(f"Configuration file {config_file} not found")


### PR DESCRIPTION
Thanks to #81 we can now access simulation data from the GUI. However, we need to mount the correct volume. The Spin settings have been changed to mount `/global/cfs/cdirs/m558/superfacility/git` instead of only `/global/cfs/cdirs/m558/superfacility/git/ml`. This PR updates the GUI source code to work correctly with the new settings.