### PR TITLE
GUI: Add expansion panels, clean up design and code

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -281,11 +281,11 @@ def home_route():
                                         with vuetify.VSlider(
                                             v_model_number=("opacity",),
                                             change="flushState('opacity')",
-                                            classes="align-center",
                                             hide_details=True,
                                             max=1.0,
                                             min=0.0,
                                             step=0.025,
+                                            style="align-items: center;",
                                         ):
                                             with vuetify.Template(v_slot_append=True):
                                                 vuetify.VTextField(
@@ -294,7 +294,7 @@ def home_route():
                                                     hide_details=True,
                                                     readonly=True,
                                                     single_line=True,
-                                                    style="width: 80px; margin-top: 0px; padding-top: 0px;",
+                                                    style="margin-top: 0px; padding-top: 0px; width: 80px;",
                                                     type="number",
                                                 )
             # plots card

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -135,7 +135,7 @@ class ModelManager:
                             items=("Models", model_type_list),
                             dense=True,
                             prepend_icon="mdi-brain",
-                            style="max-width: 210px; margin-top: 24px; margin-left: 16px;",
+                            style="margin-left: 16px; margin-top: 24px; max-width: 210px;",
                         )
                     # create a row for the switches and buttons
                     with vuetify.VRow():
@@ -144,7 +144,7 @@ class ModelManager:
                                 "Retrain",
                                 # click=self.retrain,  # TODO define callback
                                 disabled=True,  # TODO conditional on state
-                                style="margin-top: 12px; margin-left: 4px; text-transform: none;",
+                                style="margin-left: 4px; margin-top: 12px; text-transform: none;",
                             )
                         with vuetify.VCol():
                             vuetify.VSwitch(

--- a/dashboard/parameters_manager.py
+++ b/dashboard/parameters_manager.py
@@ -60,9 +60,9 @@ class ParametersManager:
                             vuetify.VSubheader(
                                 key,
                                 style=(
-                                    "margin-top: 16px"
+                                    "margin-top: 16px;"
                                     if count == 0
-                                    else "margin-top: 0px"
+                                    else "margin-top: 0px;"
                                 ),
                             )
                         # create a row for the slider and text field
@@ -70,21 +70,20 @@ class ParametersManager:
                             with vuetify.VSlider(
                                 v_model_number=(f"parameters['{key}']",),
                                 change="flushState('parameters')",
-                                classes="align-center",
                                 hide_details=True,
                                 max=pmax,
                                 min=pmin,
                                 step=step,
+                                style="align-items: center;",
                             ):
                                 with vuetify.Template(v_slot_append=True):
                                     vuetify.VTextField(
                                         v_model_number=(f"parameters['{key}']",),
-                                        classes="mt-0 pt-0",
                                         density="compact",
                                         hide_details=True,
                                         readonly=True,
                                         single_line=True,
-                                        style="width: 80px;",
+                                        style="margin-top: 0px; padding-top: 0px; width: 80px;",
                                         type="number",
                                     )
                     # create a row for the buttons
@@ -93,11 +92,11 @@ class ParametersManager:
                             vuetify.VBtn(
                                 "Reset",
                                 click=self.reset,
-                                style="margin-top: 12px; margin-left: 4px; text-transform: none;",
+                                style="margin-left: 4px; margin-top: 12px; text-transform: none;",
                             )
                         with vuetify.VCol():
                             vuetify.VBtn(
                                 "Optimize",
                                 click=self.optimize,
-                                style="margin-top: 12px; margin-left: 12px; text-transform: none;",
+                                style="margin-left: 12px; margin-top: 12px; text-transform: none;",
                             )


### PR DESCRIPTION
To-do:
- [x] Convert the control cards to expansion panels that are expanded by default when the app is launched.
- [x] Add disabled button to retrain the ML model - to be implemented in a separate PR.
- [x] Clean up the designs of the panels and the underlying source code.
- [x] Convert all args `classes="..."` to the equivalent `style="..."`, which is more verbose and self-explanatory.

Examples of the new layout:
![Screenshot from 2025-06-09 16-23-13](https://github.com/user-attachments/assets/56947f28-da0a-41cb-922b-b247f9ad5c45)
![Screenshot from 2025-06-09 16-23-21](https://github.com/user-attachments/assets/8c782608-5b65-4f8f-81b8-f88041f9ecc0)
![Screenshot from 2025-06-09 16-23-27](https://github.com/user-attachments/assets/5d0ef69b-b2ed-45ec-adc0-873bd2a5bddb)
![Screenshot from 2025-06-09 16-23-34](https://github.com/user-attachments/assets/4685bcc2-c8b3-4c7f-a87a-ae9a88a47c96)

