### PR TITLE
[WIP] Add human-readable labels for variables in dashboard

### DIFF
--- a/dashboard/config/variables.yml
+++ b/dashboard/config/variables.yml
@@ -16,6 +16,7 @@ qed_ip2:
   output_variables:
     output1:
       name: "energy_in_harmonics"
+      display_name: "Energy in Harmonics"
       type: scalar
 
 ip2:

--- a/dashboard/objectives_manager.py
+++ b/dashboard/objectives_manager.py
@@ -10,8 +10,11 @@ class ObjectivesManager:
         self.__model = model
         # define state variables
         state.objectives = dict()
-        for _, objective_dict in output_variables.items():
+        state.objectives_display_name = dict()
+        for objective_dict in output_variables.values():
             key = objective_dict["name"]
+            state.objectives_display_name[key] = objective_dict.get("display_name", key)
+
             if model.avail():
                 state.objectives[key], lower, upper = model.evaluate(state.parameters)
             else:

--- a/dashboard/parameters_manager.py
+++ b/dashboard/parameters_manager.py
@@ -13,7 +13,8 @@ class ParametersManager:
         state.parameters = dict()
         state.parameters_min = dict()
         state.parameters_max = dict()
-        for _, parameter_dict in input_variables.items():
+        state.parameters_display_name = dict()
+        for parameter_dict in input_variables.values():
             key = parameter_dict["name"]
             pmin = float(parameter_dict["value_range"][0])
             pmax = float(parameter_dict["value_range"][1])
@@ -21,6 +22,7 @@ class ParametersManager:
             state.parameters[key] = pval
             state.parameters_min[key] = pmin
             state.parameters_max[key] = pmax
+            state.parameters_display_name[key] = parameter_dict.get("display_name", key)
         state.parameters_init = copy.deepcopy(state.parameters)
 
     @property
@@ -58,7 +60,7 @@ class ParametersManager:
                         # create a row for the parameter label
                         with vuetify.VRow():
                             vuetify.VSubheader(
-                                key,
+                                state.parameters_display_name[key],
                                 style=(
                                     "margin-top: 16px;"
                                     if count == 0

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -162,12 +162,15 @@ def plot(model_manager):
     parameters = state.parameters
     parameters_min = state.parameters_min
     parameters_max = state.parameters_max
+    parameters_display_name = state.parameters_display_name
     try:
         # FIXME generalize for multiple objectives
         objective_name = list(state.objectives.keys())[0]
+        objective_display_name = state.objectives_display_name[objective_name]
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
         objective_name = ""
+        objective_display_name = ""
     # load experimental data
     df_exp = pd.read_json(StringIO(state.exp_data_serialized))
     df_sim = pd.read_json(StringIO(state.sim_data_serialized))
@@ -314,15 +317,16 @@ def plot(model_manager):
         # figures style
         fig.update_xaxes(
             exponentformat="e",
-            title_text=key,
+            title_text=parameters_display_name[key],
             row=this_row,
             col=this_col,
         )
         fig.update_yaxes(
             exponentformat="e",
-            title_text=objective_name,
+            title_text=objective_display_name,
             row=this_row,
             col=this_col,
         )
+
     fig.update_layout(clickmode="event")
     return fig


### PR DESCRIPTION
closes #147 
Adds the optional key `display_name` to a parameter or objective that, when set, will set the parameter's display name in graphs and in the sidebar and the objective's display name in the graphs.

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/9816091e-3fa1-4689-b9c8-960caaf3319d" />
