### PR TITLE
Do not raise an exception if the model file is missing

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -49,7 +49,7 @@ def load_model_file():
         print(f"Model file {model_file} not found")
         model_file = None
     elif not metadata_match(config_file, model_file):
-        print(f"Model file {model_file} does not match configuration file")
+        print(f"Model file {model_file} does not match configuration file {config_file}")
         model_file = None
     return model_file
 


### PR DESCRIPTION
This is a bit of a choice, but I think that the intended behavior is that the dashboard should be robust when model files are missing (in this case, the dashboard should simply not plot the model, instead of throwing an error). 

This PR makes the corresponding changes. 