### PR TITLE
Reorganize path where the NN and GP models are saved/read

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -42,7 +42,7 @@ def load_model_file():
     model_type_tag = model_type_tag_dict[state.model_type]
     # find model file in the local file system
     model_dir = os.path.join(
-        os.getcwd(), "..", "ml", f"{model_type_tag}_training", "saved_models"
+        os.getcwd(), "..", "ml", "saved_models", f"{model_type_tag}_training",
     )
     model_file = os.path.join(model_dir, f"{state.experiment}.yml")
     if not os.path.isfile(model_file):

--- a/ml/NN_training/mongo_NN.py
+++ b/ml/NN_training/mongo_NN.py
@@ -54,7 +54,7 @@ from Neural_Net_Classes import CombinedNN as CombinedNN
 with open("/global/cfs/cdirs/m558/superfacility/model_training/src/variables.yml") as f:
     yaml_dict = yaml.safe_load( f.read() )
 input_variables = yaml_dict[experiment]["input_variables"]
-input_names = [ v['name'] for v in input_variables.values() ] 
+input_names = [ v['name'] for v in input_variables.values() ]
 output_variables = yaml_dict[experiment]["output_variables"]
 output_names = [ v['name'] for v in output_variables.values() ]
 
@@ -75,14 +75,14 @@ df = pd.concat( (df_exp[variables], df_sim[variables]) )
 # Normalize with Affine Input Transformer
 # Define the input and output normalizations
 X = torch.tensor( df[ input_names ].values, dtype=torch.float )
-input_transform = AffineInputTransform( 
-    len(input_names), 
-    coefficient=X.std(axis=0), 
+input_transform = AffineInputTransform(
+    len(input_names),
+    coefficient=X.std(axis=0),
     offset=X.mean(axis=0)
 )
 y = torch.tensor( df[ output_names ].values, dtype=torch.float )
-output_transform = AffineInputTransform( 
-    len(output_names), 
+output_transform = AffineInputTransform(
+    len(output_names),
     coefficient=y.std(axis=0),
     offset=y.mean(axis=0)
 )
@@ -102,21 +102,21 @@ norm_sim_outputs_training = torch.tensor( norm_df[norm_df.experiment_flag==0][ou
 calibrated_nn = CombinedNN( len(input_names), len(output_names), learning_rate=0.0005)
 calibrated_nn.train_model(
     norm_sim_inputs_training, norm_sim_outputs_training,
-    norm_expt_inputs_training, norm_expt_outputs_training, 
+    norm_expt_inputs_training, norm_expt_outputs_training,
     num_epochs=20000)
 
 
 # Saving the Lume Model - TO do for combined NN
-calibration_transform = AffineInputTransform( 
-    len(output_names), 
-    coefficient=calibrated_nn.sim_to_exp_calibration.weight.clone(), 
+calibration_transform = AffineInputTransform(
+    len(output_names),
+    coefficient=calibrated_nn.sim_to_exp_calibration.weight.clone(),
     offset=calibrated_nn.sim_to_exp_calibration.bias.clone() )
 
 # Fix mismatch in name between the config file and the expected lume-model format
 for k in input_variables:
     print(input_variables[k])
     input_variables[k]['default_value'] = input_variables[k]['default']
-    del input_variables[k]['default']  
+    del input_variables[k]['default']
 
 model = TorchModel(
     model=calibrated_nn,
@@ -125,4 +125,4 @@ model = TorchModel(
     input_transformers=[input_transform],
     output_transformers=[calibration_transform,output_transform] # saving calibration before normalization
 )
-model.dump( file=os.path.join(path_to_IFE_sf_src+'/ml/NN_training/saved_models', experiment+'.yml'), save_jit=True )
+model.dump( file=os.path.join(path_to_IFE_sf_src+'/ml/saved_models/NN_training/', experiment+'.yml'), save_jit=True )


### PR DESCRIPTION
Instead of saving the models in `ml/NN_training/saved_models`and `ml/GP_training/saved_models`, we now save them in `ml/saved_models/NN_training` and `ml/saved_models/GP_training/`

So the overall expected file structure of the `ml` folder is:
```
ml/
        NN_training/mongo_NN.py
        GP_training/MultiTaskGP_training_lume.ipynb
        saved_models/
              NN_training/ .... .jit
              GP_training/ .... .jit
```

Next step:
- [x] Reproduce the `ml/saved_models` structure at NERSC
  - [x] Make new directories and copy existing files
  - [x] Delete existing files from old directories
    - [x] `/global/cfs/cdirs/m558/superfacility/ml/NN_training/`
    - [x] `/global/cfs/cdirs/m558/superfacility/ml/GP_training/`
- [x] Mount `ml/saved_models` on Spin instead of the full `ml` folder

Later on: the automatic training of GP models PR (https://github.com/ECP-WarpX/2024_IFE-superfacility/pull/129) will need to be updated accordingly.

Someone who would like to visualize the model locally would for now need to create the folder `saved_models` and save it there.