### PR TITLE
Establish connection to the database only once

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -59,7 +59,7 @@ def update(
     exp_data, sim_data = load_data(db)
     # reset model
     if reset_model:
-        mod_manager = ModelManager()
+        mod_manager = ModelManager(db)
     # load input and output variables
     input_variables, output_variables, simulation_calibration = load_variables()
     # reset parameters

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -15,9 +15,9 @@ from utils import load_model_file
 
 
 class ModelManager:
-    def __init__(self):
+    def __init__(self, db):
         print("Initializing model manager...")
-        model_file = load_model_file()
+        model_file = load_model_file(db)
         if model_file is None:
             self.__model = None
         else:

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -32,7 +32,7 @@ def load_config_dict():
     return config_dict
 
 
-def load_model_file():
+def load_model_file(db):
     # dictionary of auxiliary model types tags
     model_type_tag_dict = {
         "Gaussian Process": "GP",
@@ -41,7 +41,6 @@ def load_model_file():
     model_type_tag = model_type_tag_dict[state.model_type]
 
     # Download model information from the database
-    db = load_database()
     collection = db['models']
     query = {'experiment': state.experiment, 'model_type': model_type_tag}
     count = collection.count_documents(query)


### PR DESCRIPTION
In the previous code, we were re-establishing the connection to the database everytime we access the data.

This potentially adds latency (although I have not checked) and is not needed: even if the database gets updated (e.g. new data is added), we will get the new points whenever calling the `pymongodb` `find` method (even without re-establishing the connection)