### PR TITLE
Fix error with Spin permissions

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -17,6 +17,9 @@ COPY ml/NN_training/mongo_NN.py /app/ml/NN_training/mongo_NN.py
 COPY ml/NN_training/Neural_Net_Classes.py /app/ml/NN_training/Neural_Net_Classes.py
 COPY automation/launch_model_training/training_pm.sbatch /app/automation/launch_model_training/training_pm.sbatch
 
+# Create directory for downloaded models
+RUN mkdir -p /app/dashboard/downloaded_model
+
 # Install any needed packages specified in the environment file
 RUN conda install -c conda-forge conda-lock \
     && conda-lock install --name gui gui-lock.yml

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -57,10 +57,13 @@ def load_model_file():
         # Save model files to the local file system
         # - Prepare path on the local file system
         model_dir = 'downloaded_model'
-        # - Remove the directory if it exists
-        if os.path.exists(model_dir):
-            shutil.rmtree(model_dir)
-        os.makedirs(model_dir)
+        if not os.path.exists(model_dir):
+            # Create the directory if it does not exist
+            os.makedirs(model_dir)
+        else:
+            # else remove the previous model
+            for file in os.listdir(model_dir):
+                os.remove(os.path.join(model_dir, file))
         # - Save the model yaml file
         yaml_file_content = document['yaml_file_content']
         with open(os.path.join(model_dir, state.experiment+'.yml'), 'w') as f:


### PR DESCRIPTION
It seems that creating new directories in the Spin app, leads to a permission error:
```
Initializing model manager...
2025-07-11T18:18:51.272856545Z Traceback (most recent call last):
  File "/app/dashboard/app.py", line 389, in <module>
2025-07-11T18:18:51.273033649Z     update()
2025-07-11T18:18:51.273058160Z   File "/app/dashboard/app.py", line 62, in update
2025-07-11T18:18:51.273145942Z     mod_manager = ModelManager(db)
2025-07-11T18:18:51.273175903Z                   ^^^^^^^^^^^^^^^^
2025-07-11T18:18:51.273193933Z   File "/app/dashboard/model_manager.py", line 20, in __init__
    model_file = load_model_file(db)
2025-07-11T18:18:51.273334377Z                  ^^^^^^^^^^^^^^^^^^^
2025-07-11T18:18:51.273337577Z   File "/app/dashboard/utils.py", line 62, in load_model_file
2025-07-11T18:18:51.273370858Z     os.makedirs(model_dir)
2025-07-11T18:18:51.273378288Z   File "<frozen os>", line 225, in makedirs
2025-07-11T18:18:51.273395918Z PermissionError: [Errno 13] Permission denied:
```
This PR tries to avoid this error.