### PR TITLE
ML Training: GPU

### DIFF
--- a/ml/training_pm.sbatch
+++ b/ml/training_pm.sbatch
@@ -14,6 +14,7 @@
 #SBATCH --constraint=gpu
 # ideally single:1, but NERSC cgroups issue
 #SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=1
 #SBATCH -o /global/cfs/cdirs/m558/superfacility/model_training/logs/sf.o%j
 #SBATCH -e /global/cfs/cdirs/m558/superfacility/model_training/logs/sf.e%j
 


### PR DESCRIPTION
Follow-up to #166 #188

Requests a GPU now, otherwise we do not get exposed one on the compute node.

Tested and fixes this behavior in the job script:
```bash
python -c "import torch; print(torch.cuda.is_available())"
# True
# Note: this is on a staging node of the batch system. We do not want to compute here.

srun python -c "import torch; print(torch.cuda.is_available())"
# False
# Note: on the actual reserved node.
```