### PR TITLE
GUI: build Docker image with BuildKit

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -2,7 +2,8 @@
 
 ### Prerequisites
 - Ensure you have Conda installed.
-- Ensure you have Docker installed (if you plan to use Docker).
+- Ensure you have Docker installed, if you plan to use Docker.
+  Minimum version recommended 23.0, to enable [BuildKit](https://docs.docker.com/build/buildkit/) by default.
 
 ### How to create a new conda environment lock file
 
@@ -78,7 +79,7 @@
 
 2. Build the Docker image based on `Dockerfile`:
     ```console
-    docker build --platform linux/amd64 -t gui -f dashboard/Dockerfile .
+    docker buildx build --platform linux/amd64 -t gui -f dashboard/Dockerfile .
     ```
 
 3. Run the Docker container from the `dashboard/` folder:


### PR DESCRIPTION
Address point 2. of #197:

> 2. We need to resolve this warning on docker build ...
> ```
> DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
>             Install the buildx component to build images with BuildKit:
>             https://docs.docker.com/go/buildx/
> ```

Note that I never saw this warning on my end.

May be because my Docker version is 28.3.2 and BuildKit is the default builder for versions > 23.0, if I understand correctly from the [BuildKit docs](https://docs.docker.com/build/buildkit/).