### PR TITLE
Add realtime querying of job status from SFAPI

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -7,7 +7,19 @@ from plotly.subplots import make_subplots
 import pymongo
 import torch
 import yaml
+import asyncio
+from sfapi_client.jobs import TERMINAL_STATES
 from state_manager import state
+
+
+async def monitor_sfapi_job(sfapi_job, state_variable):
+    while sfapi_job.state not in TERMINAL_STATES:
+        await asyncio.sleep(5)
+        await sfapi_job.update()
+        # Make the status more readable by putting in spaces and capitalizing the words
+        state[state_variable] = sfapi_job.state.value.replace("_", " ").title()
+        state.flush()
+        print("sfapi job status: ", state.model_training_status)
 
 
 def load_config_file():


### PR DESCRIPTION
Closes #164

2 major changes:
1. Use the async version of the sfapi client, so that asyncio can give control to the main event loop when we are waiting for a client and submitting the job
2. Instead of simply waiting for the job to complete, we submit the job and query it every 5 seconds for updates on its state. That way if the state changes we can update the UI

