### PR TITLE
Allow simulation_calibration to be missing

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -62,7 +62,10 @@ def load_variables():
     # dictionary of output variables (objectives)
     output_variables = config_spec["output_variables"]
     # dictionary of calibration variables
-    simulation_calibration = config_spec["simulation_calibration"]
+    if "simulation_calibration" in config_spec:
+        simulation_calibration = config_spec["simulation_calibration"]
+    else:
+        simulation_calibration = {}
     return (input_variables, output_variables, simulation_calibration)
 
 


### PR DESCRIPTION
This allows `simulation_calibration` to be missing in the config file for some experiment.

This is useful as we progressively develop models for a given experiment, as we will initially not feature calibration (which is the case right now for the `staging_injector` experiment, and then progressively add several calibration variables.