### PR TITLE
Miscellaneous fixes in training code

### DIFF
--- a/ml/training_pm.sbatch
+++ b/ml/training_pm.sbatch
@@ -28,6 +28,10 @@ export OMP_NUM_THREADS=1
 experiment=${1}
 model=${2}
 
+if [[ -z "${experiment}" ]]; then
+    echo "Must pass the experiment name/tag as a command line argument"
+fi
+
 # CUDA visible devices are ordered inverse to local task IDs
 #   Reference: nvidia-smi topo -m
 srun python /global/cfs/cdirs/m558/superfacility/model_training/src/train_model.py --experiment ${experiment} --model ${model}


### PR DESCRIPTION
The training script were not very robust to the cases where:
- Only simulation data is present in the training set (this is currently the case for both `acave` and `staging_injector`)
- The `simulation_calibration` is not present

This PR fixes these issues.