### PR TITLE
Communicate sfapi job failures to user

### DIFF
--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -12,8 +12,9 @@ import sys
 from lume_model.models.torch_model import TorchModel
 from lume_model.models.gp_model import GPModel
 from trame.widgets import vuetify2 as vuetify
-from utils import load_config_file, metadata_match, monitor_sfapi_job
+from utils import load_config_file, metadata_match
 from datetime import datetime
+from sfapi_manager import monitor_sfapi_job
 
 from state_manager import state
 
@@ -223,7 +224,7 @@ class ModelManager:
                 state.flush()
                 # print some logs
                 print(f"Training job submitted (job ID: {sfapi_job.jobid})")
-                await monitor_sfapi_job(sfapi_job, "model_training_status")
+                return await monitor_sfapi_job(sfapi_job, "model_training_status")
 
         except Exception as e:
             print(f"An unexpected error occurred: {e}")
@@ -234,14 +235,14 @@ class ModelManager:
             state.model_training = True
             state.model_training_status = "Submitting"
             state.flush()
-            await self.training_kernel()
-            print("Training job completed")
+            if await self.training_kernel():
+                state.model_training_time = datetime.now().strftime("%Y-%m-%d %H:%M")
+                print(f"Finished training model at {state.model_training_time}")
+            else:
+                print("Unable to complete training job.")
             # flush state and enable button
             state.model_training = False
-            state.model_training_status = "Completed"
-            state.model_training_time = datetime.now().strftime("%Y-%m-%d %H:%M")
             state.flush()
-            print(f"Finished training model at {state.model_training_time}")
         except Exception as e:
             print(f"An unexpected error occurred: {e}")
 

--- a/dashboard/sfapi_manager.py
+++ b/dashboard/sfapi_manager.py
@@ -3,8 +3,21 @@ import os
 from sfapi_client import Client
 from sfapi_client.compute import Machine
 from trame.widgets import vuetify2 as vuetify
+import asyncio
+from sfapi_client.jobs import TERMINAL_STATES, JobState
 
 from state_manager import state
+
+
+async def monitor_sfapi_job(sfapi_job, state_variable):
+    while sfapi_job.state not in TERMINAL_STATES:
+        await asyncio.sleep(5)
+        await sfapi_job.update()
+        # Make the status more readable by putting in spaces and capitalizing the words
+        state[state_variable] = sfapi_job.state.value.replace("_", " ").title()
+        state.flush()
+        print("sfapi job status: ", state.model_training_status)
+    return sfapi_job.state == JobState.COMPLETED
 
 
 def parse_sfapi_key(key_str):

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -7,19 +7,7 @@ from plotly.subplots import make_subplots
 import pymongo
 import torch
 import yaml
-import asyncio
-from sfapi_client.jobs import TERMINAL_STATES
 from state_manager import state
-
-
-async def monitor_sfapi_job(sfapi_job, state_variable):
-    while sfapi_job.state not in TERMINAL_STATES:
-        await asyncio.sleep(5)
-        await sfapi_job.update()
-        # Make the status more readable by putting in spaces and capitalizing the words
-        state[state_variable] = sfapi_job.state.value.replace("_", " ").title()
-        state.flush()
-        print("sfapi job status: ", state.model_training_status)
 
 
 def load_config_file():


### PR DESCRIPTION
Fixed #213 
3 changes:
1. Do not overwrite the `model_training_status` state variable to `"Completed"` when the job fails
2. Only update the `model_training_time` state variable if the model training job was actually successful
3. Move the `monitor_sfapi_job` function to `sfapi_manager.py` instead of `utils.py` (it seemed more at home there)