### PR TITLE
Fix simulation close icon on a newline

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -370,15 +370,16 @@ def gui_setup():
         # interactive dialog for simulation plots
         with vuetify.VDialog(v_model=("simulation_dialog",), max_width="600"):
             with vuetify.VCard(style="overflow: hidden;"):
-                with vuetify.VCardTitle():
-                    with vuetify.VRow(align="center"):
-                        html.H3("Simulation Plots")
-                        vuetify.VSpacer()
-                        vuetify.VBtn(
-                            click=close_simulation_dialog,
-                            icon="mdi-close",
-                            variant="plain",
-                        )
+                with vuetify.VCardTitle(
+                    "Simulation Plots",
+                    classes="d-flex align-center",
+                ):
+                    vuetify.VSpacer()
+                    vuetify.VBtn(
+                        click=close_simulation_dialog,
+                        icon="mdi-close",
+                        variant="plain",
+                    )
                 with vuetify.VRow(align="center", justify="center"):
                     html.Video(
                         v_if=("simulation_video",),


### PR DESCRIPTION
Fixes #218

It looks like in Vuetify3 the `VCardTitle` component now displays its children on separate lines instead of in the same line. To fix, I wrap the title and the close icon in a VRow.
<img width="1893" height="951" alt="image" src="https://github.com/user-attachments/assets/ee8af73d-bc0c-427f-b206-c158f950463e" />
