### PR TITLE
Cleaner way to upload new ML model

### DIFF
--- a/ml/train_model.py
+++ b/ml/train_model.py
@@ -303,16 +303,9 @@ with tempfile.TemporaryDirectory() as temp_dir:
     if count > 1:
         print(f"Multiple models found for experiment: {experiment} and model type: {model_type}! Removing them.")
         db['models'].delete_many(query)
-        count = db['models'].count_documents(query)
-    if count == 0:
-        print("Uploading new model to database")
-        db['models'].insert_one(document)
-        print("Model uploaded to database")
     elif count == 1:
-        print('Model already exists in database ; updating it.')
-        db['models'].update_one(query, {'$set': document})
-    else:
-        # Raise error, this should not happen
-        raise ValueError(f"Multiple models found for experiment: {experiment} and model type: {model_type}!")
-
-    print("Model updated in database")
+        print(f"Model already exists for experiment: {experiment} and model type: {model_type}! Removing it.")
+        db['models'].delete_one(query)
+    print("Uploading new model to database")
+    db['models'].insert_one(document)
+    print("Model uploaded to database")


### PR DESCRIPTION
When updating the ML model, in principle, it is cleaner to remove the previous version of the ML and upload a new one (with `insert_one`), rather than updating one (with `update_one`).

This is because the old and new model could have different keys ; consider for instance the following hypothetical scenario, where e.g. due to a some random update, the name of one of the keys has been changed:
```
old_document = { 'yaml_file_content': '...', ... }
new_document = { 'yaml_content': '...', ...}
```
using `update_one`, would result in a document in the database to contains both `'yaml_file_content'` and `'yaml_content'`, which is somewhat dirty.