### PR TITLE
Take up 80% of the screen for simulation pop-ups

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -386,19 +386,19 @@ def gui_setup():
                 with vuetify.VRow(
                     align="center",
                     justify="center",
-                    style="flex: 1 1 auto; width: 100%; height: 100%;",
+                    style="width: 100%; height: 100%;",
                 ):
                     html.Video(
                         v_if=("simulation_video",),
                         controls=True,
                         src=("simulation_url",),
-                        style="width: 100%; height: 100%; object-fit: contain;",
+                        style="width: 100%; height: 100%",
                     )
                     vuetify.VImg(
                         v_if=("!simulation_video",),
                         src=("simulation_url",),
                         contain=True,
-                        style="width: 100%; height: 100%; object-fit: contain;",
+                        style="width: 100%; height: 100%",
                     )
 
 


### PR DESCRIPTION
Fixes #223

Instead of a hardcoded value for the simulation animation pop-up size, take up 80% of the screen with the window. This way we can dynamically resize!


https://github.com/user-attachments/assets/1e639e10-fd45-417c-8c8d-d198c538c4de

