### PR TITLE
Simplify implementation of VSelect components

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -374,7 +374,7 @@ def gui_setup():
             vuetify.VSelect(
                 v_model=("experiment",),
                 label="Experiments",
-                items=("experiments", experiment_list),
+                items=(experiment_list,),
                 dense=True,
                 hide_details=True,
                 prepend_icon="mdi-atom",

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -244,7 +244,7 @@ class ModelManager:
                             vuetify.VSelect(
                                 v_model=("model_type",),
                                 label="Model type",
-                                items=("models", model_type_list),
+                                items=(model_type_list,),
                                 dense=True,
                             )
                         with vuetify.VCol():

--- a/dashboard/optimization_manager.py
+++ b/dashboard/optimization_manager.py
@@ -81,7 +81,7 @@ class OptimizationManager:
                             vuetify.VSelect(
                                 v_model=("optimization_type",),
                                 label="Optimization type",
-                                items=("optimization", optimization_type_list),
+                                items=(optimization_type_list,),
                                 dense=True,
                             )
                         with vuetify.VCol():


### PR DESCRIPTION
Close #230.

Match the same implementation as
https://github.com/ECP-WarpX/2024_IFE-superfacility/blob/eca68d6976ca2b143cc3454299f93cc8764b6799/dashboard/outputs_manager.py#L24-L29
where `items` is a `(list,)` instead of a `(str, list)`.