### PR TITLE
Train one separate GP for each output to avoid NaN issues

### DIFF
--- a/ml/train_model.py
+++ b/ml/train_model.py
@@ -240,7 +240,7 @@ else:
         print(f"Processing output {i+1}/{n_outputs}: {output_name}")
 
         # Get data where this output is not NaN
-        output_data = norm_df_train[output_names].values[:, i]
+        output_data = norm_df_train[output_name].values
         valid_mask = torch.logical_not( torch.isnan(torch.tensor(output_data)) )
         n_valid = torch.sum(valid_mask).item()
         print(f"Output {output_name}: {n_valid}/{len(output_data)} valid data points")


### PR DESCRIPTION
The data sometimes contains NaNs for **some** of the outputs ; consider for instance the following data points:
```
...
{ ... , 'Beam mean energy [GeV]': 0.6906849745323181, 'Beam energy spread [%]': 2.0915586841749376, 'Trapped charge [pC]': 0.019345790007806805}
{ ..., 'Beam mean energy [GeV]': nan, 'Beam energy spread [%]': nan, 'Trapped charge [pC]': -0.0}
...
```
For the second data point, the mean energy and energy spread are `nan` because the corresponding charge is 0.

In this case, we would like to take into account all points when building a model that predicts the charge, but only the non-nan points when building a model that predicts the beam energy or energy spread.

For GPs, this is achieved with the botorch class `ModelListGP`: we train separate GPs for each output (charge, beam energy, beam energy spread) on distinct datasets (obtained by filtering out the NaNs for each of the outputs) and combine them using `ModelListGP`.

I have tested the training script and made sure that it saves the model properly in the database. No changes are needed in the dashboard code to correctly download and plot the model (the model still uses the same lume-model interface)

I will update the training routines for NN (to make them work with NaNs) in a separate PR.