### PR TITLE
Span full width for output selector

### DIFF
--- a/dashboard/outputs_manager.py
+++ b/dashboard/outputs_manager.py
@@ -18,14 +18,10 @@ class OutputManager:
                 style="font-size: 20px; font-weight: 500;",
             ):
                 with vuetify.VExpansionPanelText():
-                    # create a row for the switches and buttons
                     with vuetify.VRow():
-                        with vuetify.VCol():
-                            vuetify.VSelect(
-                                v_model=("displayed_output",),
-                                items=(state.output_variables,),
-                                change="flushState('displayed_output')",
-                                dense=True,
-                            )
-                        with vuetify.VCol():
-                            pass  # empty column to match alignment of selectors in other panels
+                        vuetify.VSelect(
+                            v_model=("displayed_output",),
+                            items=(state.output_variables,),
+                            change="flushState('displayed_output')",
+                            dense=True,
+                        )


### PR DESCRIPTION
The names of the output variables can span many characters, including units, and it is probably important to avoid cropping the selector.

Main branch:
<img width="687" height="234" alt="Screenshot from 2025-08-19 16-42-32" src="https://github.com/user-attachments/assets/bc400f8e-76a0-4778-94e2-fbefa606dc46" />

This branch:
<img width="687" height="205" alt="Screenshot from 2025-08-19 16-44-50" src="https://github.com/user-attachments/assets/d3ee856c-c17c-46c0-b90d-64c8b5032df2" />