### PR TITLE
Make NN training robust to NaN

### DIFF
--- a/ml/Neural_Net_Classes.py
+++ b/ml/Neural_Net_Classes.py
@@ -52,7 +52,7 @@ def nan_mse_loss( target, pred ):
     return mse_loss
 
 
-class CombinedNN(nn.Module):()
+class CombinedNN(nn.Module):
     """
     Model that trains a 5 layer neural network and a calibration layer
     """


### PR DESCRIPTION
Follow-up to #232 

NaNs correspond to missing values in the dataset and should be simply ignored in the loss function. In the case of neural network this can be achieved by using `nanmean` when computing the MSE.

However, due to the details of pytorch, even though NaNs are ignored in the loss function, they can still propagate in the gradients. (This is not mathematically expected, but results from the inner workings of `pytorch`, as described here: https://github.com/pytorch/pytorch/issues/4132). To avoid this, here we use hooks in the gradient calculation that remove NaN in the gradients.