### PR TITLE
Show all outputs when hovering

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -214,7 +214,7 @@ def plot(exp_data, sim_data, model_manager, cal_manager):
                 y=objective_name,
                 opacity=df_copy_filtered["opacity"],
                 color_discrete_sequence=[df_cds[df_count]],
-                hover_data=list(state.parameters.keys()),
+                hover_data=list(state.parameters.keys()) + state.output_variables,
                 custom_data="_id",
             )
             # do now show default legend affected by opacity map


### PR DESCRIPTION
- Before this PR:
<img width="707" height="364" alt="Screenshot 2025-08-20 at 3 38 16 PM" src="https://github.com/user-attachments/assets/82f4cd03-aa5a-43f2-875d-f2519f46c5f0" />

- After this PR (ignore the different aspect ratio ; the PR did not change this, I was just not cautious enough when taking the screen shots):
<img width="1068" height="371" alt="Screenshot 2025-08-20 at 3 35 57 PM" src="https://github.com/user-attachments/assets/28d1148d-242d-40c1-bac2-f8d013aa538d" />
(note that beam energy, beam energy spread, and mean laser wavelength now appear)
