### PR TITLE
Make Gaussian Process the default model

### DIFF
--- a/dashboard/state_manager.py
+++ b/dashboard/state_manager.py
@@ -12,7 +12,7 @@ def initialize_state():
     print("Initializing state variables at startup...")
     # experiment and model type
     state.experiment = "qed_ip2"
-    state.model_type = "Neural Network"
+    state.model_type = "Gaussian Process"
     state.model_training = False
     state.model_training_status = None
     state.model_training_time = None


### PR DESCRIPTION
My impression from recent interactions with the dashboard is that Gaussian Process predictions are smoother and seem more physically sensible.

In addition, the training of neural network currently fails with the `staging_injector` because of NaNs. I am trying to fix this in #237 