### PR TITLE
Extract electrons from background plasma from simulations

### DIFF
--- a/simulation_data/staging_injector/templates/inputs
+++ b/simulation_data/staging_injector/templates/inputs
@@ -148,4 +148,5 @@ diag.dt_snapshots_lab = 2.75e-12
 diag.intervals = 1:40
 diag.format = openpmd
 diag.fields_to_plot = Er Et Ez
-diag.species = electrons_n1
+diag.species = electrons_n1 electrons1
+diag.electrons1.plot_filter_function(t,x,y,z,ux,uy,uz) = (uz>10)


### PR DESCRIPTION
Up to now the simulation scripts were only extracting the electrons from ionization injection. 
In this PR, we also extract electrons from the background plasma.