### PR TITLE
Update movie of the laser spectrum for `staging_injector`

### DIFF
--- a/simulation_data/staging_injector/templates/analyze_simulation.py
+++ b/simulation_data/staging_injector/templates/analyze_simulation.py
@@ -192,7 +192,7 @@ def analyze_simulation():
         S, info = ts.get_laser_spectral_intensity(iteration=iteration, pol=pol)
         lambd = 2*np.pi/info.k[1:]
         plt.xlabel(r'Wavelength [$\mu m$]')
-        plt.title('Laser spectrum [J/\mu m]')
+        plt.title('Laser spectrum [$J/\mu m$]')
         plt.plot( 1.e6*lambd, 1e-6*S[1:]/lambd**2, color='r' )
         plt.xlim(0.5,1.2)
 


### PR DESCRIPTION
This updates the calculation of the laser spectrum.

Instead of using the function `get_spectrum` -- which computes the FFT of the on-axis electric field --  this uses the function `get_laser_spectral_intensity` (from [this branch of openPMD-viewer](https://github.com/openPMD/openPMD-viewer/pull/441) -- which computes the spectrum of the full laser (not only an on-axis slice)