### PR TITLE
Remove unhelpful print statements in train_model.py

### DIFF
--- a/ml/train_model.py
+++ b/ml/train_model.py
@@ -321,7 +321,6 @@ with tempfile.TemporaryDirectory() as temp_dir:
         model.dump(file=os.path.join(temp_dir, experiment+'.yml'), save_models=True )
     # Upload the model to the database
     # - Load the files that were just created into a dictionary
-    print("Loading model from temp dir")
     with open(os.path.join(temp_dir, experiment+'.yml')) as f:
         yaml_file_content = f.read()
     document = {


### PR DESCRIPTION
Some of the `print` statements are not particularly informative, and tend to clutter the logs.

Typical log **after** this PR:
```
Must pass the experiment name/tag as a command line argument
Device selected:  cuda
Experiment: qed_ip2, Model type: NN
training started
Epoch [2000/20000], Loss:0.529188, Val Loss:0.935963
Early stopping triggered at, 2433  "with val loss ", 0.931833
Model_1 trained in  9.140794277191162
Total time taken: 111.17 seconds
Data prep time taken: 39.89 seconds
NN time taken: 71.29 seconds
Uploading new model to database
Model uploaded to database
```

Typical log **before** this PR:
```
Must pass the experiment name/tag as a command line argument
Device selected:  cuda
Experiment: qed_ip2, Model type: NN
training started
Epoch [2000/20000], Loss:0.529188, Val Loss:0.935963
Early stopping triggered at, 2433  "with val loss ", 0.931833
Model_1 trained in  9.140794277191162
{'name': 'Prepulse Delay', 'type': 'scalar', 'default': 70, 'value_range': [67.41, 71.41]}
{'name': 'Target focus', 'type': 'scalar', 'default': -56.84, 'value_range': [-56.87, -56.81]}
Total time taken: 111.17 seconds
Data prep time taken: 39.89 seconds
NN time taken: 71.29 seconds
Loading model from temp dir
{'experiment': 'qed_ip2', 'model_type': 'NN', 'yaml_file_content': 'model_class: TorchModel\ninput_variables:\n  Prepulse Delay:\n    variable_class: ScalarVariable\n    default_value: 70.0\n    is_constant: false\n    value_range: [67.41, 71.41]\n    value_range_tolerance: 1.0e-08\n  Target focus:\n    variable_class: ScalarVariable\n    default_value: -56.84\n    is_constant: false\n    value_range: [-56.87, -56.81]\n    value_range_tolerance: 1.0e-08\noutput_variables:\n  harmonic_signal: {variable_class: ScalarVariable, is_constant: false, value_range_tolerance: 1.0e-08}\ninput_validation_config: null\noutput_validation_config: null\nmodel: qed_ip2_model.jit\ninput_transformers: [qed_ip2_input_transformers_0.pt]\noutput_transformers: [qed_ip2_output_transformers_0.pt, qed_ip2_output_transformers_1.pt]\noutput_format: tensor\ndevice: cpu\nfixed_model: true\nprecision: double\n'}
Uploading new model to database
Model uploaded to database
```