### PR TITLE
Change hover fields to only display 6 sigfigs

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -264,9 +264,7 @@ def plot(exp_data, sim_data, model_manager, cal_manager):
                 ]
                 hover_customdata += hover_simulation
                 hover_template_lines += hover_section(
-                    "Simulation",
-                    hover_simulation,
-                    hover_customdata,
+                    "Simulation", hover_simulation, hover_customdata
                 )
 
             exp_fig = px.scatter(


### PR DESCRIPTION
<img width="651" height="406" alt="image" src="https://github.com/user-attachments/assets/52df30d7-f72d-4109-921e-ad26f68f419e" />
Uses only 6 sig figs for the data when displaying...

Unfortunately, there is no `hovertemplate` argument given by the trame version of plotly, and that's usually how you'd change the format of the hover display https://plotly.com/python/hover-text-and-formatting/#advanced-hover-template

I got around this by creating a new column in the data frame that contains the formatted hover text for each data point, and displaying that as the `hover_name` for each point. 

Closes #266 