### PR TITLE
Fix style of Perlmutter status logging info

### DIFF
--- a/dashboard/sfapi_manager.py
+++ b/dashboard/sfapi_manager.py
@@ -86,7 +86,7 @@ def update_sfapi_info():
                 state.perlmutter_description = f"{status.description}"
                 state.perlmutter_status = f"{status.status.value}"
                 print(
-                    f"Perlmutter status is {state.perlmutter_status} with description {state.perlmutter_description}"
+                    f"Perlmutter status is {state.perlmutter_status} with description '{state.perlmutter_description}'"
                 )
             else:
                 # reset key expiration date


### PR DESCRIPTION
Two-character style fix for the Perlmutter status info we log to terminal.

Print this
```
Perlmutter status is active with description 'System is active'
```
instead of this
```
Perlmutter status is active with description System is active
```
which I think is less easy to read because of the grammar.