### PR TITLE
Group widgets into tabs

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -268,12 +268,16 @@ def home_route():
         with vuetify.VRow():
             with vuetify.VCol(cols=4):
                 with vuetify.VCard():
-                    with vuetify.VTabs(v_model=("active_tab", "tab0"), color="primary", mandatory=True):
-                        vuetify.VTab("Parameters", value="tab0")
-                        vuetify.VTab("Otimization", value="tab1")
-                        vuetify.VTab("ML", value="tab2")
-                    with vuetify.VWindow(v_model=("active_tab", "tab0"), mandatory=True):
-                        with vuetify.VWindowItem(value="tab0"):
+                    with vuetify.VTabs(
+                        v_model=("active_tab", "parameters_tab"),
+                        color="primary",
+                        mandatory=True,
+                    ):
+                        vuetify.VTab("Parameters", value="parameters_tab")
+                        vuetify.VTab("Optimization", value="optimization_tab")
+                        vuetify.VTab("ML", value="ml_tab")
+                    with vuetify.VWindow(v_model=("active_tab",), mandatory=True):
+                        with vuetify.VWindowItem(value="parameters_tab"):
                             # output control panel
                             with vuetify.VRow():
                                 with vuetify.VCol():
@@ -286,12 +290,12 @@ def home_route():
                             with vuetify.VRow():
                                 with vuetify.VCol():
                                     data_depth_panel()
-                        with vuetify.VWindowItem(value="tab1"):
+                        with vuetify.VWindowItem(value="optimization_tab"):
                             # optimization control panel
                             with vuetify.VRow():
                                 with vuetify.VCol():
                                     opt_manager.panel()
-                        with vuetify.VWindowItem(value="tab2"):
+                        with vuetify.VWindowItem(value="ml_tab"):
                             # model control panel
                             with vuetify.VRow():
                                 with vuetify.VCol():

--- a/dashboard/state_manager.py
+++ b/dashboard/state_manager.py
@@ -40,5 +40,3 @@ def initialize_state():
     # Errors management
     state.errors = []
     state.error_counter = 0
-    # tabs
-    state.active_tab = "tab0"


### PR DESCRIPTION
In order to avoid having to scroll down and/or use the collapsible widget, it is useful to have tabs:
<img width="462" height="568" alt="Screenshot 2025-10-31 at 6 09 02 AM" src="https://github.com/user-attachments/assets/d26a3d1c-5613-452b-9710-13a1b494387a" />
