### PR TITLE
Fix model not automatically reloading

### DIFF
--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -234,6 +234,7 @@ class ModelManager:
             state.flush()
             if await self.training_kernel():
                 state.model_training_time = datetime.now().strftime("%Y-%m-%d %H:%M")
+                state.flush()
                 print(f"Finished training model at {state.model_training_time}")
             else:
                 print("Unable to complete training job.")


### PR DESCRIPTION
Closes #267 

Looking at https://github.com/BLAST-AI-ML/synapse/blob/main/dashboard/app.py#L122-L136, we can see that we only reload the models if the number of state variables changed is 1 (so we don't reload it a bunch of times during initialization). Because the `training_async` function happens on a different thread, when we call `state.flush()` both the `model_training_time` and the `model_training` variables were being flushed with changes at the same time! This meant that we were never reloading the model. 

To fix, just flush the new `model_training_time` before we change `model_training`...