### PR TITLE
Fix title style in ML panels

### DIFF
--- a/dashboard/calibration_manager.py
+++ b/dashboard/calibration_manager.py
@@ -45,7 +45,10 @@ class SimulationCalibrationManager:
     def panel(self):
         print("Setting calibration card...")
         with vuetify.VExpansionPanels(v_model=("expand_panel_control_calibration", 0)):
-            with vuetify.VExpansionPanel(title="Control: Calibrate simulation points"):
+            with vuetify.VExpansionPanel(
+                title="Control: Calibrate simulation points",
+                style="font-size: 20px; font-weight: 500;",
+            ):
                 with vuetify.VExpansionPanelText():
                     with client.DeepReactive("simulation_calibration"):
                         for key in state.simulation_calibration.keys():


### PR DESCRIPTION
Minor style fix for the title of the calibration panel in the ML tab.

Before this PR the style was not matching:
<img width="300" alt="Screenshot from 2025-11-13 11-41-17" src="https://github.com/user-attachments/assets/37dd4407-8db0-4e07-8b2d-0e12d755fedc" />

Here we use the same style as for all other titles, e.g.,
https://github.com/BLAST-AI-ML/synapse/blob/b315707258d3c34b3c89e8f84ec1b993cf409dec/dashboard/parameters_manager.py#L153-L156