### PR TITLE
Update Ruff pre-commit hook version to v0.14.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version
-  rev: v0.11.12
+  rev: v0.14.4
   hooks:
     # Run the linter
     - id: ruff-check


### PR DESCRIPTION
This will be updated automatically once we will have a pre-commit CI workflow.