### PR TITLE
Ignore untracked subdirectories in experiments/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *__pycache__/
 *.ipynb_checkpoints/
 
+# Experiments
+experiments/*/
+
 # JetBrains IDE idea directories
 .idea/


### PR DESCRIPTION
We should ignore untracked subdirectories in the experiments/ directory, i.e., local clones of private experiment repositories.