### PR TITLE
Fix calibration manager list titles

### DIFF
--- a/dashboard/calibration_manager.py
+++ b/dashboard/calibration_manager.py
@@ -54,12 +54,13 @@ class SimulationCalibrationManager:
                         for key in state.simulation_calibration.keys():
                             # create a row for the parameter label
                             with vuetify.VRow():
-                                vuetify.VListSubheader(
+                                vuetify.VListItemTitle(
                                     state.simulation_calibration[key]["name"]
                                 )
                             with vuetify.VRow():
                                 html.Small(
-                                    f"= α × ({state.simulation_calibration[key]['depends_on']} - β)"
+                                    f"= α × ({state.simulation_calibration[key]['depends_on']} - β)",
+                                    style="font-weight: lighter;",
                                 )
                             with vuetify.VRow():
                                 with vuetify.VCol():


### PR DESCRIPTION
Fix the calibration manager titles so that the `=𝛼x(...` text is less bold than the variable name above.

<img width="606" height="455" alt="image" src="https://github.com/user-attachments/assets/a8c6eceb-57d1-450d-8548-a984587e7df8" />

Issue spotted here:
https://github.com/BLAST-AI-ML/synapse/pull/319#issuecomment-3530354941