### PR TITLE
Fix calibration manager list titles (continued)

### DIFF
--- a/dashboard/calibration_manager.py
+++ b/dashboard/calibration_manager.py
@@ -54,13 +54,9 @@ class SimulationCalibrationManager:
                         for key in state.simulation_calibration.keys():
                             # create a row for the parameter label
                             with vuetify.VRow():
-                                vuetify.VListItemTitle(
-                                    state.simulation_calibration[key]["name"]
-                                )
-                            with vuetify.VRow():
                                 html.Small(
-                                    f"= α × ({state.simulation_calibration[key]['depends_on']} - β)",
-                                    style="font-weight: lighter;",
+                                    f"<b> {state.simulation_calibration[key]['name']}</b> = α × (<b>{state.simulation_calibration[key]['depends_on']}</b> - β)",
+                                    style="font-weight: lighter; font-size: 70%;",
                                 )
                             with vuetify.VRow():
                                 with vuetify.VCol():


### PR DESCRIPTION
Make the list titles one line and bold the variable names, and also make the text a bit smaller than the title above:
<img width="611" height="357" alt="image" src="https://github.com/user-attachments/assets/6d5dc8d1-0854-4899-8290-63cc65c6156e" />
