### PR TITLE
Upload config files to nersc

### DIFF
--- a/ml/training_pm.sbatch
+++ b/ml/training_pm.sbatch
@@ -49,4 +49,9 @@ echo "Container check/pull took ${SECONDS} seconds."
 
 # CUDA visible devices are ordered inverse to local task IDs
 #   Reference: nvidia-smi topo -m
-srun podman-hpc run --gpu -v /etc/localtime:/etc/localtime -v $HOME/db.profile:/root/db.profile --rm -it ${REGISTRY_NAME}/${IMAGE_NAME}:${IMAGE_VERSION} python -u /app/ml/train_model.py --experiment ${experiment} --model ${model}
+srun podman-hpc run --gpu \
+    -v /etc/localtime:/etc/localtime \
+    -v $HOME/db.profile:/root/db.profile \
+    -v /global/cfs/cdirs/m558/superfacility/model_training/config.yaml:/app/ml/config.yaml \
+    --rm -it ${REGISTRY_NAME}/${IMAGE_NAME}:${IMAGE_VERSION} \
+    python -u /app/ml/train_model.py --experiment ${experiment} --model ${model}


### PR DESCRIPTION
Fixes #335

Uploads the gui's configuration file to nersc and mounts that file to the docker container so that ML training takes into account the gui configuration values

Example: Here with default configuration values:
<img width="1840" height="914" alt="Screenshot 2025-12-09 at 2 29 00 PM" src="https://github.com/user-attachments/assets/e777dbd4-9e2f-4972-bf4c-e31ca75ae9a0" />

and here with an updated `alpha` for `target_to_distance` (you can see the ML model is correctly changed to a different shape)
<img width="1867" height="920" alt="Screenshot 2025-12-09 at 2 27 59 PM" src="https://github.com/user-attachments/assets/887263a4-bedd-4b83-91ef-45676fcc986c" />
