### PR TITLE
Fix ML Container Pull: Remote SHA

### DIFF
--- a/ml/training_pm.sbatch
+++ b/ml/training_pm.sbatch
@@ -32,9 +32,9 @@ IMAGE_VERSION="latest"
 
 podman-hpc login --username "${REGISTRY_USER}" --password "${REGISTRY_PASSWORD}" ${REGISTRY_NAME}
 LOCAL_SHA="sha256:"$(podman-hpc images --digests --format "{{.Id}}" ${REGISTRY_NAME}/${IMAGE_NAME}:${IMAGE_VERSION})
-# OCI_FILE_TYPES defines the expected format, for the content returned by the `curl` command below
+# OCI_FILE_TYPES defines the expected format
 # See https://specs.opencontainers.org/image-spec/manifest/#oci-image-manifest-specification
-OCI_FILE_TYPES="application/vnd.oci.image.manifest.v1+json"  # official spec for the modern OCI format
+OCI_FILE_TYPES="application/vnd.oci.image.manifest.v1+json"
 REMOTE_SHA=$(curl -s \
     -H "Accept: ${OCI_FILE_TYPES}" \
     -u "${REGISTRY_USER}:${REGISTRY_PASSWORD}" \


### PR DESCRIPTION
Originally not setting a header worked for me.

With tests I did again recently, I encountered caching to be broken because the remote sha showed as `null` (after parsing through `jq`) because of this permission error that I see in the response to our `curl` request:
```
{"errors":[{"code":"MANIFEST_UNKNOWN","message":"OCI manifest found, but accept header does not support OCI manifests"}]}
```
https://specs.opencontainers.org/image-spec/manifest/

Setting the HTTP request header is a common way to tell the server what file type we expect, so we do that now.

Now the container is _not_ pulled again if already present and cached in the latest version.

Follow-up to #195
Related to #302