### PR TITLE
Clean up comments in GUI conda environment base file

### DIFF
--- a/dashboard/gui-base.yml
+++ b/dashboard/gui-base.yml
@@ -1,11 +1,4 @@
-
-
-# Install latest dependencies with
-#   conda create -n gui -f gui-base.yml
-#
-# But we usually create a lockfile from this file:
-#   conda-lock --file gui-base.yml --lockfile gui-lock.yml
-#
+# See README instructions to create a lock file from this source file.
 name: gui
 channels:
   - conda-forge


### PR DESCRIPTION
I noticed the comments at the top of the GUI conda environment base file and I think it's safer to simply redirect the reader to the README instructions, to avoid duplication and/or confusion (e.g., creating the GUI base environment without lock file is not encouraged, creating the lock file requires more than a one-line command, etc.).

The README instructions should be the reference point. On ther other hand, the comments at the top of the lock file were auto-generated by `conda-lock`, so I would keep them as is:
https://github.com/BLAST-AI-ML/synapse/blob/8dc70302d1122692e92b0d16644b0993f445e1b7/dashboard/gui-lock.yml#L1-L13