### PR TITLE
Add the "_id" back into the plot custom data

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -228,7 +228,7 @@ def plot(exp_data, sim_data, model_manager, cal_manager):
             # Determine which data is shown when hovering over the plot
             hover_parameters = list(state.parameters.keys())
             hover_output_variables = state.output_variables
-            hover_customdata = hover_parameters + hover_output_variables
+            hover_customdata = ["_id"] + hover_parameters + hover_output_variables
 
             hover_template_lines = hover_section(
                 "Input variables", hover_parameters, hover_customdata


### PR DESCRIPTION
It seems that [this PR](https://github.com/BLAST-AI-ML/synapse/pull/282) removed the `_id` field from the plotly's `customdata`.

As a result, when clicking on a simulation point, [this line](https://github.com/BLAST-AI-ML/synapse/blob/main/dashboard/app.py#L167), which assumes that the `_id` is the first field in the `customdata` (which itself it quite brittle!), was returning some unrelated `float` value, for instance:
```
this_point_id 17.950310559006212
```
Ultimately leading to this error:
<img width="354" height="464" alt="Screenshot 2025-12-15 at 12 37 00 PM" src="https://github.com/user-attachments/assets/2035f958-be20-4d72-af25-ac6e41a227e4" />

It seems that the one-line change in this PR fixes the issue, but in order to be fully sure, I will need to deploy this (so that the GUI has access to the Perlmutter filesystem, which stores the simulation movies).