### PR TITLE
Use plotly.graph_objects.Scatter instead of plotly.express.scatter

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -1,7 +1,6 @@
 import numpy as np
 import os
 import pandas as pd
-import plotly.express as px
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 import pymongo
@@ -256,12 +255,17 @@ def plot(exp_data, sim_data, model_manager, cal_manager):
                     "Simulation", hover_simulation, hover_customdata
                 )
 
-            exp_fig = px.scatter(
-                df_copy_filtered,
-                x=key,
-                y=objective_name,
-                opacity=df_copy_filtered["opacity"],
-                color_discrete_sequence=[df_cds[df_count]],
+            exp_fig = go.Figure(
+                data=[
+                    go.Scatter(
+                        x=df_copy_filtered[key],
+                        y=df_copy_filtered[objective_name],
+                        mode="markers",
+                        marker=dict(
+                            color=df_cds[df_count], opacity=df_copy_filtered["opacity"]
+                        ),
+                    )
+                ]
             )
 
             # Attach customdata:


### PR DESCRIPTION
While looking into #345, I noticed that we use `plotly.graph_objects.Scatter` for all data traces in our figures except for the experimental data trace, where we used `plotly.express.scatter` instead (hiding the `plotly.graph_objects.Figure` call). I think this is not necessary and we can use `plotly.graph_objects.Scatter` for all data traces. This makes it easier to extend the code when necessary, like I was trying to do for #345.