### PR TITLE
Make the container fill the entire viewport width

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -353,7 +353,9 @@ def gui_setup():
         # set up router view
         with layout.content:
             error_panel()
-            with vuetify.VContainer(style="height: 100vh; overflow-y: auto"):
+            with vuetify.VContainer(
+                fluid=True, style="height: 100vh; overflow-y: auto"
+            ):
                 router.RouterView()
         # add router components to the drawer
         with layout.drawer:


### PR DESCRIPTION
Add `fluid=True` to `VContainer` to make the container fill the entire viewport width, allowing the column layout to use the full width correctly.

Before this PR:

<img width="400" alt="Screenshot from 2025-12-19 10-18-07" src="https://github.com/user-attachments/assets/35847eeb-4a1f-41d9-9114-d750b33a8c42" />

<img width="400" alt="Screenshot from 2025-12-19 10-18-16" src="https://github.com/user-attachments/assets/8152dd89-7cf4-48ee-a16c-b2f8bc4c0fdf" />

<br>
<br>

After this PR:

<img width="400" alt="Screenshot from 2025-12-19 10-17-42" src="https://github.com/user-attachments/assets/082a8fe9-0396-4fbe-ad47-e004ae8d1173" />

<img width="400" alt="Screenshot from 2025-12-19 10-17-49" src="https://github.com/user-attachments/assets/aa298d08-e57d-4f50-8895-9c3a9600b989" />
