### PR TITLE
Add chat route with iframe embedding

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -396,7 +396,7 @@ def gui_setup():
                 vuetify.VListItem(
                     to="/chat",
                     prepend_icon="mdi-chat",
-                    title="Chat",
+                    title="AI Chat",
                 )
         # interactive dialog for simulation plots
         with vuetify.VDialog(


### PR DESCRIPTION
This is a prototype of a chat route with iframe embedding, using the example web page https://example.com.

I have not been able to test it with an interactive page (e.g., Google home page with the search bar), because I believe most pages block iframe embedding for security reasons.

It remains to be understood whether this would work for Open WebUI, once that is set up locally.

<img width="2491" height="1244" alt="Screenshot from 2026-01-08 12-00-25" src="https://github.com/user-attachments/assets/5d4c5a01-ab85-4938-8a2d-2f7bcbb9c113" />

