### PR TITLE
Fix alignment of components in parameters control panel

### DIFF
--- a/dashboard/parameters_manager.py
+++ b/dashboard/parameters_manager.py
@@ -227,24 +227,25 @@ class ParametersManager:
                                         change="flushState('parameters_show_all')",
                                         label="Show all",
                                     )
-                        with vuetify.VRow():
-                            with vuetify.VCol():
-                                vuetify.VBtn(
-                                    "Reset",
-                                    click=self.reset,
-                                    style="text-transform: none",
-                                )
-                        with vuetify.VRow():
-                            with vuetify.VCol():
-                                vuetify.VBtn(
-                                    "Simulate",
-                                    click=self.simulation_trigger,
-                                    disabled=(
-                                        "simulation_running || perlmutter_status != 'active' || !simulatable",
-                                    ),
-                                    style="text-transform: none;",
-                                )
-                            with vuetify.VCol():
+                        with vuetify.VRow(align="center"):
+                            with vuetify.VCol(cols=6):
+                                with vuetify.VRow():
+                                    with vuetify.VCol():
+                                        vuetify.VBtn(
+                                            "Reset",
+                                            click=self.reset,
+                                            style="text-transform: none",
+                                        )
+                                    with vuetify.VCol():
+                                        vuetify.VBtn(
+                                            "Simulate",
+                                            click=self.simulation_trigger,
+                                            disabled=(
+                                                "simulation_running || perlmutter_status != 'active' || !simulatable",
+                                            ),
+                                            style="text-transform: none;",
+                                        )
+                            with vuetify.VCol(cols=6):
                                 vuetify.VTextField(
                                     v_model_number=("simulation_running_status",),
                                     label="Simulation status",


### PR DESCRIPTION
Minor fix for the alignment of some components in the parameters control panel, namely the "Reset" button, "Simulate" button, and "Simulation status" text field, taken out of #356. 

The components are now displayed on the same row, with the two buttons spanning the first half width and the text field spanning the second half width. Believe it or not, I did not find out how to center them vertically...

Before this PR:

<img width="300" alt="Screenshot from 2026-01-08 14-04-16" src="https://github.com/user-attachments/assets/489cea84-8e7a-4183-8fb1-f3f337fb6097" />

<br> <br>

After this PR:

<img width="300" alt="Screenshot from 2026-01-08 14-30-30" src="https://github.com/user-attachments/assets/ca575784-865d-4761-91ba-a0d43346638f" />

