### PR TITLE
Loop over dictionary values, not items, where sufficient

### DIFF
--- a/dashboard/calibration_manager.py
+++ b/dashboard/calibration_manager.py
@@ -49,7 +49,7 @@ class SimulationCalibrationManager:
             return alpha * (value - beta)
 
         sim_dict = {}
-        for _, value in state.simulation_calibration.items():
+        for value in state.simulation_calibration.values():
             sim_name = value["name"]
             exp_name = value["depends_on"]
             # strip characters after '[' parenthesis to remove units, strip

--- a/dashboard/parameters_manager.py
+++ b/dashboard/parameters_manager.py
@@ -28,7 +28,7 @@ class ParametersManager:
         state.simulatable = (
             self.simulation_scripts_base_path / "submission_script_single"
         ).is_file()
-        for _, parameter_dict in input_variables.items():
+        for parameter_dict in input_variables.values():
             key = parameter_dict["name"]
             pmin = float(parameter_dict["value_range"][0])
             pmax = float(parameter_dict["value_range"][1])


### PR DESCRIPTION
Minor code cleaning taken out of #356. Replace loops over dictionary `items` with loops over dictionary `values` where keys are discarded.