### PR TITLE
Fix db=None when clicking on points

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -239,7 +239,8 @@ def find_simulation(event, db):
         print(msg)
 
 
-def open_simulation_dialog(event, db):
+def open_simulation_dialog(event):
+    db = load_database(state.experiment)
     try:
         data_directory, file_path = find_simulation(event, db)
         state.simulation_video = file_path.endswith(".mp4")
@@ -323,7 +324,7 @@ def home_route():
                                 config={"responsive": True},
                                 click=(
                                     open_simulation_dialog,
-                                    "[utils.safe($event), db]",
+                                    "[utils.safe($event)]",
                                 ),
                             )
                             ctrl.figure_update = figure.update


### PR DESCRIPTION
When clicking on points in the plots, I recently got the following error:
<img width="256" height="303" alt="Screenshot 2026-01-15 at 8 53 39 AM" src="https://github.com/user-attachments/assets/c1e1edce-3407-44c6-ba1c-942ee2657db3" />

Upon investigating more, it seems that this is because the variable `db` happens to be `None` in this line:
```python
        documents = list(db[state.experiment].find({"_id": ObjectId(this_point_id)}))
```
I assume the bug was introduced in #330

I think that the proposed changes fix the issue.
