### PR TITLE
Move MLflow authentication helper into shared module

### DIFF
--- a/dashboard.Dockerfile
+++ b/dashboard.Dockerfile
@@ -24,6 +24,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 COPY dashboard /app/dashboard
 COPY experiments /app/experiments
 COPY ml/training_pm.sbatch /app/ml/training_pm.sbatch
+COPY mlflow_utils.py /app/mlflow_utils.py
 
 # Make port 8080 available to the world outside this container
 EXPOSE 8080

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -69,7 +69,7 @@ class ModelManager:
             # - inject the X-Api-Key into the requests.
             try:
                 enable_amsc_x_api_key(config_dict)
-            except KeyError as e:
+            except ValueError as e:
                 title = "AmSC MLflow authentication setup failed"
                 msg = f"Error occurred when setting up AmSC MLflow authentication: {e}"
                 add_error(title, msg)

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 import tempfile
 import os
+import sys
 import yaml
 import re
 import urllib3
@@ -11,57 +12,21 @@ import mlflow
 from sfapi_client import AsyncClient
 from sfapi_client.compute import Machine
 from trame.widgets import vuetify3 as vuetify
+
+# Add parent directory to path so we can import mlflow_utils from root
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
 from utils import timer, load_config_dict, create_date_filter
 from error_manager import add_error
 from sfapi_manager import monitor_sfapi_job
 from state_manager import state
+from mlflow_utils import enable_amsc_x_api_key
 
 model_type_tag_dict = {
     "Gaussian Process": "GP",
     "Neural Network (single)": "NN",
     "Neural Network (ensemble)": "ensemble_NN",
 }
-
-
-def enable_amsc_x_api_key(config_dict):
-    """
-    MLflow authentication helper for the AmSC MLflow server.
-    Standard MLflow does not automatically inject custom headers like 'X-Api-Key'.
-    This patches the http_request function to ensure every request to the server
-    includes the AmSC API key.
-
-    See https://gitlab.com/amsc2/ai-services/model-services/intro-to-mlflow-pytorch for more details.
-    """
-    import mlflow.utils.rest_utils as rest_utils
-
-    mlflow_cfg = config_dict.get("mlflow") or {}
-    api_key_env = mlflow_cfg.get("api_key_env")
-    if not api_key_env:
-        add_error(
-            "MLFlow configuration is missing 'mlflow.api_key_env'; cannot enable AmSC X-Api-Key authentication."
-        )
-        return
-
-    api_key = os.environ.get(api_key_env)
-    if not api_key:
-        add_error(
-            f"Environment variable '{api_key_env}' (configured in 'mlflow.api_key_env') is not set; cannot enable AmSC X-Api-Key authentication."
-        )
-        return
-    _orig = rest_utils.http_request
-
-    def patched(host_creds, endpoint, method, *args, **kwargs):
-        if "headers" in kwargs and kwargs["headers"] is not None:
-            h = dict(kwargs["headers"])
-            h["X-Api-Key"] = api_key
-            kwargs["headers"] = h
-        else:
-            h = dict(kwargs.get("extra_headers") or {})
-            h["X-Api-Key"] = api_key
-            kwargs["extra_headers"] = h
-        return _orig(host_creds, endpoint, method, *args, **kwargs)
-
-    rest_utils.http_request = patched
 
 
 class ModelManager:
@@ -93,7 +58,7 @@ class ModelManager:
 
         mlflow.set_tracking_uri(config_dict["mlflow"]["tracking_uri"])
         # When using the AmSC MLflow:
-        # (See https://gitlab.com/amsc2/ai-services/model-services/intro-to-mlflow-pytorch)
+        # (see https://gitlab.com/amsc2/ai-services/model-services/intro-to-mlflow-pytorch)
         if (
             config_dict["mlflow"]["tracking_uri"]
             == "https://mlflow.american-science-cloud.org"
@@ -102,7 +67,13 @@ class ModelManager:
             os.environ["MLFLOW_TRACKING_INSECURE_TLS"] = "true"
             urllib3.disable_warnings(InsecureRequestWarning)
             # - inject the X-Api-Key into the requests.
-            enable_amsc_x_api_key(config_dict)
+            try:
+                enable_amsc_x_api_key(config_dict)
+            except KeyError as e:
+                title = "AmSC MLflow authentication setup failed"
+                msg = f"Error occurred when setting up AmSC MLflow authentication: {e}"
+                add_error(title, msg)
+                print(msg)
         model_name = f"{state.experiment}_{model_type_tag}"
 
         try:

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -1,25 +1,27 @@
 import asyncio
-from datetime import datetime
-from pathlib import Path
 import os
 import re
 import sys
 import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import mlflow
 import urllib3
 import yaml
-import mlflow
 from sfapi_client import AsyncClient
 from sfapi_client.compute import Machine
 from trame.widgets import vuetify3 as vuetify
+from urllib3.exceptions import InsecureRequestWarning
 
 # Add parent directory to path so we can import mlflow_utils from root
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from utils import timer, load_config_dict, create_date_filter
 from error_manager import add_error
+from mlflow_utils import enable_amsc_x_api_key
 from sfapi_manager import monitor_sfapi_job
 from state_manager import state
-from mlflow_utils import enable_amsc_x_api_key
+from utils import timer, load_config_dict, create_date_filter
 
 model_type_tag_dict = {
     "Gaussian Process": "GP",
@@ -52,7 +54,7 @@ class ModelManager:
         ):
             # Tell MLflow to ignore SSL certificate errors (common with self-signed internal servers)
             os.environ["MLFLOW_TRACKING_INSECURE_TLS"] = "true"
-            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            urllib3.disable_warnings(InsecureRequestWarning)
             # Inject the X-Api-Key into the requests.
             try:
                 enable_amsc_x_api_key(config_dict)

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -50,10 +50,10 @@ class ModelManager:
             config_dict["mlflow"]["tracking_uri"]
             == "https://mlflow.american-science-cloud.org"
         ):
-            # - tell MLflow to ignore SSL certificate errors (common with self-signed internal servers)
+            # Tell MLflow to ignore SSL certificate errors (common with self-signed internal servers)
             os.environ["MLFLOW_TRACKING_INSECURE_TLS"] = "true"
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-            # - inject the X-Api-Key into the requests.
+            # Inject the X-Api-Key into the requests.
             try:
                 enable_amsc_x_api_key(config_dict)
             except ValueError as e:

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -1,12 +1,12 @@
 import asyncio
 from datetime import datetime
 from pathlib import Path
-import tempfile
 import os
-import sys
-import yaml
 import re
+import sys
+import tempfile
 import urllib3
+import yaml
 import mlflow
 from sfapi_client import AsyncClient
 from sfapi_client.compute import Machine

--- a/ml.Dockerfile
+++ b/ml.Dockerfile
@@ -28,6 +28,7 @@ ENTRYPOINT ["/app/ml/entrypoint.sh"]
 COPY ml/train_model.py /app/ml/train_model.py
 COPY ml/Neural_Net_Classes.py /app/ml/Neural_Net_Classes.py
 COPY experiments /app/experiments
+COPY mlflow_utils.py /app/mlflow_utils.py
 
 # Run train_model.py when the container launches
 CMD ["python", "-u", "train_model.py"]

--- a/ml/train_model.py
+++ b/ml/train_model.py
@@ -28,9 +28,13 @@ from sklearn.model_selection import train_test_split
 import sys
 import pandas as pd
 from gpytorch.mlls import ExactMarginalLogLikelihood
+from pathlib import Path
 
-sys.path.append(".")
+# Add parent directories to path for module imports
+sys.path.insert(0, str(Path(__file__).parent.parent))  # For mlflow_utils in root
+sys.path.insert(0, str(Path(__file__).parent))  # For Neural_Net_Classes in ml/
 from Neural_Net_Classes import CombinedNN
+from mlflow_utils import enable_amsc_x_api_key
 
 # measure the time it took to import everything
 import_end_time = time.time()
@@ -374,52 +378,6 @@ def train_gp(
     )
 
 
-def enable_amsc_x_api_key(config_dict):
-    """
-    MLflow authentication helper for the AmSC MLflow server.
-    Standard MLflow does not automatically inject custom headers like 'X-Api-Key'.
-    This patches the http_request function to ensure every request to the server
-    includes the AmSC API key.
-
-    See https://gitlab.com/amsc2/ai-services/model-services/intro-to-mlflow-pytorch for more details.
-    """
-    import mlflow.utils.rest_utils as rest_utils
-
-    mlflow_cfg = config_dict.get("mlflow") if config_dict is not None else None
-    if not isinstance(mlflow_cfg, dict):
-        raise KeyError(
-            "Missing 'mlflow' configuration section required for AmSC MLFlow authentication."
-        )
-
-    api_key_env = mlflow_cfg.get("api_key_env")
-    if not api_key_env:
-        raise KeyError(
-            "Missing 'api_key_env' in 'mlflow' configuration. "
-            "Please specify the name of the environment variable containing the AmSC API key."
-        )
-
-    api_key = os.getenv(api_key_env)
-    if api_key is None:
-        raise KeyError(
-            f"The environment variable '{api_key_env}' specified in 'mlflow.api_key_env' "
-            "is not set. Please export it with the AmSC MLFlow API key."
-        )
-    _orig = rest_utils.http_request
-
-    def patched(host_creds, endpoint, method, *args, **kwargs):
-        if "headers" in kwargs and kwargs["headers"] is not None:
-            h = dict(kwargs["headers"])
-            h["X-Api-Key"] = api_key
-            kwargs["headers"] = h
-        else:
-            h = dict(kwargs.get("extra_headers") or {})
-            h["X-Api-Key"] = api_key
-            kwargs["extra_headers"] = h
-        return _orig(host_creds, endpoint, method, *args, **kwargs)
-
-    rest_utils.http_request = patched
-
-
 def register_model_to_mlflow(model, model_type, experiment, config_dict):
     """Register the trained model to MLflow (tracking URI from config)."""
     tracking_uri = config_dict["mlflow"]["tracking_uri"]
@@ -471,7 +429,7 @@ if __name__ == "__main__":
     df_sim = pd.DataFrame(db[experiment].find({"experiment_flag": 0}))
 
     # When using the AmSC MLflow:
-    # (See https://gitlab.com/amsc2/ai-services/model-services/intro-to-mlflow-pytorch)
+    # (see https://gitlab.com/amsc2/ai-services/model-services/intro-to-mlflow-pytorch)
     if (
         "mlflow" in config_dict
         and config_dict["mlflow"].get("tracking_uri")

--- a/mlflow_utils.py
+++ b/mlflow_utils.py
@@ -34,7 +34,7 @@ def enable_amsc_x_api_key(config_dict):
             "Please specify the name of the environment variable containing the AmSC API key."
         )
 
-    api_key = os.getenv(api_key_env)
+    api_key = os.environ.get(api_key_env)
     if api_key is None:
         raise ValueError(
             f"The environment variable '{api_key_env}' specified in 'mlflow.api_key_env' "
@@ -44,14 +44,9 @@ def enable_amsc_x_api_key(config_dict):
     _orig = rest_utils.http_request
 
     def patched(host_creds, endpoint, method, *args, **kwargs):
-        if "headers" in kwargs and kwargs["headers"] is not None:
-            h = dict(kwargs["headers"])
-            h["X-Api-Key"] = api_key
-            kwargs["headers"] = h
-        else:
-            h = dict(kwargs.get("extra_headers") or {})
-            h["X-Api-Key"] = api_key
-            kwargs["extra_headers"] = h
+        h = dict(kwargs.get("headers") or kwargs.get("extra_headers") or {})
+        h["X-Api-Key"] = api_key
+        kwargs["headers" if "headers" in kwargs else "extra_headers"] = h
         return _orig(host_creds, endpoint, method, *args, **kwargs)
 
     rest_utils.http_request = patched

--- a/mlflow_utils.py
+++ b/mlflow_utils.py
@@ -15,7 +15,7 @@ def enable_amsc_x_api_key(config_dict):
         config_dict: Configuration dictionary containing mlflow settings
 
     Raises:
-        KeyError: If required mlflow configuration is missing or invalid
+        ValueError: If required mlflow configuration is missing or invalid
 
     See https://gitlab.com/amsc2/ai-services/model-services/intro-to-mlflow-pytorch for more details.
     """
@@ -23,20 +23,20 @@ def enable_amsc_x_api_key(config_dict):
 
     mlflow_cfg = config_dict.get("mlflow") if config_dict is not None else None
     if not isinstance(mlflow_cfg, dict):
-        raise KeyError(
+        raise ValueError(
             "Missing 'mlflow' configuration section required for AmSC MLFlow authentication."
         )
 
     api_key_env = mlflow_cfg.get("api_key_env")
     if not api_key_env:
-        raise KeyError(
+        raise ValueError(
             "Missing 'api_key_env' in 'mlflow' configuration. "
             "Please specify the name of the environment variable containing the AmSC API key."
         )
 
     api_key = os.getenv(api_key_env)
     if api_key is None:
-        raise KeyError(
+        raise ValueError(
             f"The environment variable '{api_key_env}' specified in 'mlflow.api_key_env' "
             "is not set. Please export it with the AmSC MLFlow API key."
         )

--- a/mlflow_utils.py
+++ b/mlflow_utils.py
@@ -1,0 +1,57 @@
+"""MLflow utility functions for AmSC authentication and configuration."""
+
+import os
+
+
+def enable_amsc_x_api_key(config_dict):
+    """
+    MLflow authentication helper for the AmSC MLflow server.
+
+    Standard MLflow does not automatically inject custom headers like 'X-Api-Key'.
+    This patches the http_request function to ensure every request to the server
+    includes the AmSC API key.
+
+    Args:
+        config_dict: Configuration dictionary containing mlflow settings
+
+    Raises:
+        KeyError: If required mlflow configuration is missing or invalid
+
+    See https://gitlab.com/amsc2/ai-services/model-services/intro-to-mlflow-pytorch for more details.
+    """
+    import mlflow.utils.rest_utils as rest_utils
+
+    mlflow_cfg = config_dict.get("mlflow") if config_dict is not None else None
+    if not isinstance(mlflow_cfg, dict):
+        raise KeyError(
+            "Missing 'mlflow' configuration section required for AmSC MLFlow authentication."
+        )
+
+    api_key_env = mlflow_cfg.get("api_key_env")
+    if not api_key_env:
+        raise KeyError(
+            "Missing 'api_key_env' in 'mlflow' configuration. "
+            "Please specify the name of the environment variable containing the AmSC API key."
+        )
+
+    api_key = os.getenv(api_key_env)
+    if api_key is None:
+        raise KeyError(
+            f"The environment variable '{api_key_env}' specified in 'mlflow.api_key_env' "
+            "is not set. Please export it with the AmSC MLFlow API key."
+        )
+
+    _orig = rest_utils.http_request
+
+    def patched(host_creds, endpoint, method, *args, **kwargs):
+        if "headers" in kwargs and kwargs["headers"] is not None:
+            h = dict(kwargs["headers"])
+            h["X-Api-Key"] = api_key
+            kwargs["headers"] = h
+        else:
+            h = dict(kwargs.get("extra_headers") or {})
+            h["X-Api-Key"] = api_key
+            kwargs["extra_headers"] = h
+        return _orig(host_creds, endpoint, method, *args, **kwargs)
+
+    rest_utils.http_request = patched


### PR DESCRIPTION
This pull request refactors the MLflow authentication helper for AmSC servers into a dedicated utility module, and updates both the dashboard and model training code to use this shared implementation. The main benefit is improved code reuse and maintainability, as well as more robust error handling when setting up authentication for MLflow requests. Additionally, Dockerfiles are updated to include the new utility module.

**Shared MLflow authentication utility**

* Extracted the `enable_amsc_x_api_key` function from both `dashboard/model_manager.py` and `ml/train_model.py` into a new shared file `mlflow_utils.py`, centralizing AmSC MLflow authentication logic and improving maintainability.

**Codebase updates to use the utility**

* Updated imports and sys.path handling in both `dashboard/model_manager.py` and `ml/train_model.py` to import `enable_amsc_x_api_key` from the new `mlflow_utils.py` module, replacing previous local implementations.
* Improved error handling when setting up AmSC MLflow authentication in `dashboard/model_manager.py` by catching `ValueError` and reporting errors to the user.

**Dockerfile changes**

* Added `mlflow_utils.py` to both `dashboard.Dockerfile` and `ml.Dockerfile` to ensure the utility is available in the container environments.

**Minor improvements**

* Updated comments to reference the correct AmSC MLflow documentation link and made minor formatting fixes.

**Reference**

The code should copy from:
* https://gitlab.com/amsc2/ai-services/model-services/intro-to-mlflow-pytorch
* https://gitlab.com/amsc2/ai-services/model-services/intro-to-mlflow-pytorch/-/blob/main/model_registry/upload_external_model.py