### PR TITLE
Add local execution mode for ML training

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -475,7 +475,7 @@ def gui_setup():
 
 if __name__ == "__main__":
     # parse command-line arguments
-    parser = argparse.ArgumentParser(description="Synapse Dashboard")
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         "--local",
         action="store_true",

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -68,7 +68,7 @@ def update(
     config_dict = load_config_dict(state.experiment)
     # derive execution mode from execution_mode in the experiment configuration file
     execution_mode = config_dict.get("execution_mode") or {}
-    state.model_training_local = execution_mode.get("ml_training", "local")
+    state.model_training_mode = execution_mode.get("ml_training", "local")
     db = load_database(config_dict)
     exp_data, sim_data = load_data(db, state.experiment, state.experiment_date_range)
     # reset output
@@ -79,7 +79,7 @@ def update(
         mod_manager = ModelManager(
             config_dict=config_dict,
             model_type=model_type_dict[state.model_type_verbose],
-            model_training_local=state.model_training_local,
+            model_training_mode=state.model_training_mode,
         )
         opt_manager = OptimizationManager(mod_manager)
     # reset parameters

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,4 +1,3 @@
-import argparse
 from bson.objectid import ObjectId
 import os
 import re
@@ -67,6 +66,9 @@ def update(
     )
     # load data
     config_dict = load_config_dict(state.experiment)
+    # derive local_mode from local_execution in the experiment config
+    local_execution = config_dict.get("local_execution", {})
+    state.model_training_local = bool(local_execution.get("ml_training", False))
     db = load_database(config_dict)
     exp_data, sim_data = load_data(db, state.experiment, state.experiment_date_range)
     # reset output
@@ -77,7 +79,7 @@ def update(
         mod_manager = ModelManager(
             config_dict=config_dict,
             model_type_tag=model_type_tag_dict[state.model_type],
-            local_mode=state.local_mode,
+            model_training_local=state.model_training_local,
         )
         opt_manager = OptimizationManager(mod_manager)
     # reset parameters
@@ -474,17 +476,8 @@ def gui_setup():
 # -----------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    # parse command-line arguments
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--local",
-        action="store_true",
-        help="Run ML model training locally instead of on Perlmutter",
-    )
-    args, _ = parser.parse_known_args()
     # initialize state variables needed at startup
     initialize_state()
-    state.local_mode = args.local
     # initialize Superfacility API
     initialize_sfapi()
     # update for the first time

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -82,7 +82,6 @@ def update(
         mod_manager = ModelManager(
             config_dict=config_dict,
             model_type=model_type_dict[state.model_type_verbose],
-            model_training_mode=state.model_training_mode,
         )
         opt_manager = OptimizationManager(mod_manager)
     # reset parameters

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,3 +1,4 @@
+import argparse
 from bson.objectid import ObjectId
 import os
 import re
@@ -76,6 +77,7 @@ def update(
         mod_manager = ModelManager(
             config_dict=config_dict,
             model_type_tag=model_type_tag_dict[state.model_type],
+            local_mode=state.local_mode,
         )
         opt_manager = OptimizationManager(mod_manager)
     # reset parameters
@@ -472,8 +474,17 @@ def gui_setup():
 # -----------------------------------------------------------------------------
 
 if __name__ == "__main__":
+    # parse command-line arguments
+    parser = argparse.ArgumentParser(description="Synapse Dashboard")
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Run ML model training locally instead of on Perlmutter",
+    )
+    args, _ = parser.parse_known_args()
     # initialize state variables needed at startup
     initialize_state()
+    state.local_mode = args.local
     # initialize Superfacility API
     initialize_sfapi()
     # update for the first time

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -66,8 +66,8 @@ def update(
     )
     # load data
     config_dict = load_config_dict(state.experiment)
-    # derive local_mode from local_execution in the experiment config
-    local_execution = config_dict.get("local_execution", {})
+    # derive local_execution from local_execution in the experiment config
+    local_execution = config_dict.get("local_execution") or {}
     state.model_training_local = bool(local_execution.get("ml_training", False))
     db = load_database(config_dict)
     exp_data, sim_data = load_data(db, state.experiment, state.experiment_date_range)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -66,9 +66,9 @@ def update(
     )
     # load data
     config_dict = load_config_dict(state.experiment)
-    # derive local_execution from local_execution in the experiment config
-    local_execution = config_dict.get("local_execution") or {}
-    state.model_training_local = bool(local_execution.get("ml_training", False))
+    # derive execution mode from execution_mode in the experiment configuration file
+    execution_mode = config_dict.get("execution_mode") or {}
+    state.model_training_local = execution_mode.get("ml_training", "local")
     db = load_database(config_dict)
     exp_data, sim_data = load_data(db, state.experiment, state.experiment_date_range)
     # reset output

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import datetime
 from pathlib import Path
+import sys
 import tempfile
 import os
 import yaml
@@ -65,13 +66,14 @@ def enable_amsc_x_api_key(config_dict):
 
 
 class ModelManager:
-    def __init__(self, config_dict, model_type_tag):
+    def __init__(self, config_dict, model_type_tag, local_mode=False):
         print("Initializing model manager...")
         self.__model = None
         self.__is_neural_network = False
         self.__is_gaussian_process = False
         self.__is_neural_network_ensemble = False
         self.__model_type_tag = model_type_tag
+        self.__local_mode = local_mode
 
         if "mlflow" not in config_dict or not config_dict["mlflow"].get("tracking_uri"):
             print(
@@ -161,6 +163,20 @@ class ModelManager:
         if self.__model is not None:
             return self.__model.output_transformers
 
+    def _prepare_training_config(self, temp_dir):
+        """Prepare a merged training config YAML in the given temp directory.
+
+        Returns the path to the written config file.
+        """
+        config_dict = load_config_dict(state.experiment)
+        config_dict["simulation_calibration"] = state.simulation_calibration
+        date_filter = create_date_filter(state.experiment_date_range)
+        config_dict["date_filter"] = date_filter
+        config_path = Path(temp_dir) / "config.yaml"
+        with open(config_path, "w") as f:
+            yaml.dump(config_dict, f)
+        return config_path
+
     async def training_kernel(self):
         try:
             # create an authenticated client
@@ -169,20 +185,12 @@ class ModelManager:
             ) as client:
                 perlmutter = await client.compute(Machine.perlmutter)
                 # upload the configuration file to NERSC
-                config_dict = load_config_dict(state.experiment)
-                config_dict["simulation_calibration"] = state.simulation_calibration
-                # add date range filter to the configuration dictionary
-                date_filter = create_date_filter(state.experiment_date_range)
-                config_dict["date_filter"] = date_filter
-                # define the target path on NERSC
-                target_path = "/global/cfs/cdirs/m558/superfacility/model_training"
-                [target_path] = await perlmutter.ls(target_path, directory=True)
                 with tempfile.TemporaryDirectory() as temp_dir:
-                    temp_file_path = Path(temp_dir) / "config.yaml"
-                    with open(temp_file_path, "w") as temp_file:
-                        yaml.dump(config_dict, temp_file)
-                        temp_file.flush()
-                    with open(temp_file_path, "rb") as temp_file:
+                    config_path = self._prepare_training_config(temp_dir)
+                    # define the target path on NERSC
+                    target_path = "/global/cfs/cdirs/m558/superfacility/model_training"
+                    [target_path] = await perlmutter.ls(target_path, directory=True)
+                    with open(config_path, "rb") as temp_file:
                         print("Uploading config file to NERSC")
                         temp_file.filename = "config.yaml"
                         await target_path.upload(temp_file)
@@ -223,13 +231,73 @@ class ModelManager:
             add_error(title, msg)
             print(msg)
 
+    async def _training_kernel_local(self):
+        try:
+            # locate train_model.py
+            train_model_path = None
+            script_locations = [Path.cwd(), Path.cwd() / "../ml", Path.cwd() / "ml"]
+            for script_dir in script_locations:
+                candidate = script_dir / "train_model.py"
+                if candidate.exists():
+                    train_model_path = candidate.resolve()
+                    break
+            if train_model_path is None:
+                raise RuntimeError("Could not find train_model.py")
+
+            ml_dir = train_model_path.parent
+            model_tag = model_type_tag_dict[state.model_type]
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                config_path = self._prepare_training_config(temp_dir)
+                state.model_training_status = "Running"
+                state.flush()
+                print(
+                    f"Starting local training: {train_model_path} --model {model_tag}"
+                )
+                proc = await asyncio.create_subprocess_exec(
+                    sys.executable,
+                    str(train_model_path),
+                    "--config_file",
+                    str(config_path),
+                    "--model",
+                    model_tag,
+                    cwd=str(ml_dir),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                )
+                # stream subprocess output to console
+                while True:
+                    line = await proc.stdout.readline()
+                    if not line:
+                        break
+                    print(line.decode(), end="")
+                await proc.wait()
+
+            if proc.returncode == 0:
+                state.model_training_status = "Completed"
+                state.flush()
+                return True
+            else:
+                state.model_training_status = "Failed"
+                state.flush()
+                return False
+        except Exception as e:
+            title = "Unable to complete local training"
+            msg = f"Error occurred when executing local training: {e}"
+            add_error(title, msg)
+            print(msg)
+
     async def training_async(self):
         try:
             print("Training model...")
             state.model_training = True
             state.model_training_status = "Submitting"
             state.flush()
-            if await self.training_kernel():
+            if self.__local_mode:
+                result = await self._training_kernel_local()
+            else:
+                result = await self.training_kernel()
+            if result:
                 state.model_training_time = datetime.now().strftime("%Y-%m-%d %H:%M")
                 state.flush()
                 print(f"Finished training model at {state.model_training_time}")
@@ -288,7 +356,7 @@ class ModelManager:
                                 "Train",
                                 click=self.training_trigger,
                                 disabled=(
-                                    "model_training || perlmutter_status != 'active'",
+                                    "model_training || (!local_mode && perlmutter_status != 'active')",
                                 ),
                                 style="text-transform: none",
                             )

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -268,10 +268,14 @@ class ModelManager:
             state.model_training = True
             state.model_training_status = "Submitting"
             state.flush()
-            if self.__model_training_local:
+            if self.__model_training_local == "local":
                 result = await self._training_kernel_local()
-            else:
+            elif self.__model_training_local == "sfapi":
                 result = await self._training_kernel()
+            else:
+                raise ValueError(
+                    f"Unsupported training mode: {self.__model_training_local}"
+                )
             if result:
                 state.model_training_time = datetime.now().strftime("%Y-%m-%d %H:%M")
                 state.flush()
@@ -331,7 +335,7 @@ class ModelManager:
                                 "Train",
                                 click=self.training_trigger,
                                 disabled=(
-                                    "model_training || (!model_training_local && perlmutter_status != 'active')",
+                                    "model_training || (model_training_local === 'sfapi' && perlmutter_status !== 'active')",
                                 ),
                                 style="text-transform: none",
                             )

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -155,7 +155,7 @@ class ModelManager:
             yaml.dump(config_dict, f)
         return config_path
 
-    async def _training_kernel(self):
+    async def _training_kernel_sfapi(self):
         try:
             # create an authenticated client
             async with AsyncClient(
@@ -275,7 +275,7 @@ class ModelManager:
             if self.__model_training_mode == "local":
                 result = await self._training_kernel_local()
             elif self.__model_training_mode == "sfapi":
-                result = await self._training_kernel()
+                result = await self._training_kernel_sfapi()
             else:
                 raise ValueError(
                     f"Unsupported training mode: {self.__model_training_mode}"

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -177,7 +177,7 @@ class ModelManager:
             yaml.dump(config_dict, f)
         return config_path
 
-    async def training_kernel(self):
+    async def _training_kernel(self):
         try:
             # create an authenticated client
             async with AsyncClient(
@@ -296,7 +296,7 @@ class ModelManager:
             if self.__local_mode:
                 result = await self._training_kernel_local()
             else:
-                result = await self.training_kernel()
+                result = await self._training_kernel()
             if result:
                 state.model_training_time = datetime.now().strftime("%Y-%m-%d %H:%M")
                 state.flush()

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -65,11 +65,11 @@ def enable_amsc_x_api_key(config_dict):
 
 
 class ModelManager:
-    def __init__(self, config_dict, model_type, model_training_local):
+    def __init__(self, config_dict, model_type, model_training_mode):
         print("Initializing model manager...")
         self.__model = None
         self.__model_type = model_type
-        self.__model_training_local = model_training_local
+        self.__model_training_mode = model_training_mode
 
         if "mlflow" not in config_dict or not config_dict["mlflow"].get("tracking_uri"):
             print(
@@ -272,13 +272,13 @@ class ModelManager:
             state.model_training = True
             state.model_training_status = "Submitting"
             state.flush()
-            if self.__model_training_local == "local":
+            if self.__model_training_mode == "local":
                 result = await self._training_kernel_local()
-            elif self.__model_training_local == "sfapi":
+            elif self.__model_training_mode == "sfapi":
                 result = await self._training_kernel()
             else:
                 raise ValueError(
-                    f"Unsupported training mode: {self.__model_training_local}"
+                    f"Unsupported training mode: {self.__model_training_mode}"
                 )
             if result:
                 state.model_training_time = datetime.now().strftime("%Y-%m-%d %H:%M")
@@ -339,7 +339,7 @@ class ModelManager:
                                 "Train",
                                 click=self.training_trigger,
                                 disabled=(
-                                    "model_training || (model_training_local === 'sfapi' && perlmutter_status !== 'active')",
+                                    "model_training || (model_training_mode === 'sfapi' && perlmutter_status !== 'active')",
                                 ),
                                 style="text-transform: none",
                             )

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -230,6 +230,9 @@ class ModelManager:
             msg = f"Error occurred when executing remote training: {e}"
             add_error(title, msg)
             print(msg)
+            state.model_training_status = "Failed"
+            state.flush()
+            return False
 
     async def _training_kernel_local(self):
         try:

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -66,14 +66,14 @@ def enable_amsc_x_api_key(config_dict):
 
 
 class ModelManager:
-    def __init__(self, config_dict, model_type_tag, local_mode=False):
+    def __init__(self, config_dict, model_type_tag, model_training_local):
         print("Initializing model manager...")
         self.__model = None
         self.__is_neural_network = False
         self.__is_gaussian_process = False
         self.__is_neural_network_ensemble = False
         self.__model_type_tag = model_type_tag
-        self.__local_mode = local_mode
+        self.__model_training_local = model_training_local
 
         if "mlflow" not in config_dict or not config_dict["mlflow"].get("tracking_uri"):
             print(
@@ -283,7 +283,7 @@ class ModelManager:
             state.model_training = True
             state.model_training_status = "Submitting"
             state.flush()
-            if self.__local_mode:
+            if self.__model_training_local:
                 result = await self._training_kernel_local()
             else:
                 result = await self._training_kernel()
@@ -346,7 +346,7 @@ class ModelManager:
                                 "Train",
                                 click=self.training_trigger,
                                 disabled=(
-                                    "model_training || (!local_mode && perlmutter_status != 'active')",
+                                    "model_training || (!model_training_local && perlmutter_status != 'active')",
                                 ),
                                 style="text-transform: none",
                             )

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -226,8 +226,8 @@ class ModelManager:
                 print(f"Training job submitted (job ID: {sfapi_job.jobid})")
                 return await monitor_sfapi_job(sfapi_job, "model_training_status")
         except Exception as e:
-            title = "Unable to complete training kernel"
-            msg = f"Error occurred when executing training kernel: {e}"
+            title = "Unable to complete remote training"
+            msg = f"Error occurred when executing remote training: {e}"
             add_error(title, msg)
             print(msg)
 

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -192,9 +192,10 @@ class ModelManager:
         state.dirty("simulation_calibration")
 
     def _prepare_training_config(self, temp_dir):
-        """Prepare a merged training config YAML in the given temp directory.
+        """Prepare a training configuration file in the given temporary directory,
+        updated with information from the dashboard.
 
-        Returns the path to the written config file.
+        Returns the path to the written configuration file.
         """
         config_dict = load_config_dict(state.experiment)
         config_dict["simulation_calibration"] = state.simulation_calibration
@@ -219,7 +220,7 @@ class ModelManager:
                     target_path = "/global/cfs/cdirs/m558/superfacility/model_training"
                     [target_path] = await perlmutter.ls(target_path, directory=True)
                     with open(config_path, "rb") as temp_file:
-                        print("Uploading config file to NERSC")
+                        print("Uploading configuration file to NERSC...")
                         temp_file.filename = "config.yaml"
                         await target_path.upload(temp_file)
 
@@ -335,7 +336,7 @@ class ModelManager:
                 state.flush()
                 print(f"Finished training model at {state.model_training_time}")
             else:
-                print("Unable to complete training job.")
+                print("Unable to complete training job")
             # flush state and enable button
             state.model_training = False
             state.flush()

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -248,15 +248,15 @@ class ModelManager:
                     f"Starting local training: {train_model_path} --model {model_tag}"
                 )
                 proc = await asyncio.create_subprocess_exec(
-                    sys.executable,
+                    sys.executable,  # path to the currently running Python interpreter
                     str(train_model_path),
                     "--config_file",
                     str(config_path),
                     "--model",
                     model_tag,
-                    cwd=str(ml_dir),
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.STDOUT,
+                    cwd=str(ml_dir),  # working directory of the subprocess
+                    stdout=asyncio.subprocess.PIPE,  # capture the standard output into a pipe
+                    stderr=asyncio.subprocess.STDOUT,  # redirect the standard error into the same pipe
                 )
                 # stream subprocess output to console
                 while True:

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -279,6 +279,9 @@ class ModelManager:
             msg = f"Error occurred when executing local training: {e}"
             add_error(title, msg)
             print(msg)
+            state.model_training_status = "Failed"
+            state.flush()
+            return False
 
     async def training_async(self):
         try:

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -233,18 +233,8 @@ class ModelManager:
 
     async def _training_kernel_local(self):
         try:
-            # locate train_model.py
-            train_model_path = None
-            script_locations = [Path.cwd(), Path.cwd() / "../ml", Path.cwd() / "ml"]
-            for script_dir in script_locations:
-                candidate = script_dir / "train_model.py"
-                if candidate.exists():
-                    train_model_path = candidate.resolve()
-                    break
-            if train_model_path is None:
-                raise RuntimeError("Could not find train_model.py")
-
-            ml_dir = train_model_path.parent
+            ml_dir = (Path(__file__).parent / "../ml").resolve()
+            train_model_path = ml_dir / "train_model.py"
             model_tag = model_type_tag_dict[state.model_type]
 
             with tempfile.TemporaryDirectory() as temp_dir:

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -1,7 +1,6 @@
 import asyncio
 from datetime import datetime
 from pathlib import Path
-import sys
 import tempfile
 import os
 import yaml
@@ -227,7 +226,12 @@ class ModelManager:
                     f"Starting local training: {train_model_path} --model {model_type}"
                 )
                 proc = await asyncio.create_subprocess_exec(
-                    sys.executable,  # path to the currently running Python interpreter
+                    "conda",
+                    "run",
+                    "--no-capture-output",
+                    "-n",
+                    "synapse-ml",
+                    "python",
                     str(train_model_path),
                     "--config_file",
                     str(config_path),

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -65,7 +65,7 @@ def enable_amsc_x_api_key(config_dict):
 
 
 class ModelManager:
-    def __init__(self, config_dict, model_type, model_training_mode):
+    def __init__(self, config_dict, model_type):
         print("Initializing model manager...")
         self.__model = None
         self.__model_type = model_type

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -69,7 +69,6 @@ class ModelManager:
         print("Initializing model manager...")
         self.__model = None
         self.__model_type = model_type
-        self.__model_training_mode = model_training_mode
 
         if "mlflow" not in config_dict or not config_dict["mlflow"].get("tracking_uri"):
             print(
@@ -315,13 +314,13 @@ class ModelManager:
             state.model_training = True
             state.model_training_status = "Submitting"
             state.flush()
-            if self.__model_training_mode == "local":
+            if state.model_training_mode == "local":
                 result = await self._training_kernel_local()
-            elif self.__model_training_mode == "sfapi":
+            elif state.model_training_mode == "sfapi":
                 result = await self._training_kernel_sfapi()
             else:
                 raise ValueError(
-                    f"Unsupported training mode: {self.__model_training_mode}"
+                    f"Unsupported training mode: {state.model_training_mode}"
                 )
             if result:
                 state.model_training_time = datetime.now().strftime("%Y-%m-%d %H:%M")

--- a/dashboard/state_manager.py
+++ b/dashboard/state_manager.py
@@ -29,7 +29,7 @@ def initialize_state():
     # ML model
     state.model_type_verbose = "Neural Network (single)"
     state.model_training = False
-    state.model_training_local = False
+    state.model_training_local = "local"
     state.model_training_status = None
     state.model_training_time = None
     # Optimization

--- a/dashboard/state_manager.py
+++ b/dashboard/state_manager.py
@@ -29,7 +29,7 @@ def initialize_state():
     # ML model
     state.model_type_verbose = "Neural Network (single)"
     state.model_training = False
-    state.model_training_local = "local"
+    state.model_training_mode = "local"
     state.model_training_status = None
     state.model_training_time = None
     # Optimization

--- a/dashboard/state_manager.py
+++ b/dashboard/state_manager.py
@@ -29,6 +29,7 @@ def initialize_state():
     # ML model
     state.model_type = "Neural Network (single)"
     state.model_training = False
+    state.model_training_local = False
     state.model_training_status = None
     state.model_training_time = None
     # Optimization
@@ -57,5 +58,3 @@ def initialize_state():
     state.error_counter = 0
     # Calibration toggles
     state.use_inferred_calibration = False
-    # Execution mode
-    state.local_mode = False

--- a/dashboard/state_manager.py
+++ b/dashboard/state_manager.py
@@ -57,3 +57,5 @@ def initialize_state():
     state.error_counter = 0
     # Calibration toggles
     state.use_inferred_calibration = False
+    # Execution mode
+    state.local_mode = False

--- a/ml/train_model.py
+++ b/ml/train_model.py
@@ -461,7 +461,7 @@ if __name__ == "__main__":
             df_val, input_names, input_normalization, output_names, output_normalization
         )
 
-    print("training started")
+    print("Training started")
     train_start_time = time.time()
     ######################################################
     # Neural Net and Ensemble Creation and training
@@ -486,7 +486,7 @@ if __name__ == "__main__":
             device,
         )
 
-    print("training ended")
+    print("Training ended")
 
     end_time = time.time()
 

--- a/tests/check_model.py
+++ b/tests/check_model.py
@@ -36,13 +36,12 @@ def load_experimental_data(config_dict):
     return exp_data, input_names, output_names
 
 
-def check_evaluate(config_dict, model_type, model_training_mode):
+def check_evaluate(config_dict, model_type):
     """Load model and evaluate with experimental data; verify accuracy (relative RMSE <= threshold)."""
     # Load model
     mm = ModelManager(
         config_dict=config_dict,
         model_type=model_type,
-        model_training_mode=model_training_mode,
     )
     # Load experimental data
     df_exp, input_names, output_names = load_experimental_data(config_dict)
@@ -111,7 +110,7 @@ if __name__ == "__main__":
 
     # Load model and evaluate with experimental data
     try:
-        check_evaluate(config_dict, args.model, model_training_mode="local")
+        check_evaluate(config_dict, args.model)
     except Exception as e:
         print(f"[FAIL] {e}")
         sys.exit(1)

--- a/tests/check_model.py
+++ b/tests/check_model.py
@@ -36,10 +36,14 @@ def load_experimental_data(config_dict):
     return exp_data, input_names, output_names
 
 
-def check_evaluate(config_dict, model_type):
+def check_evaluate(config_dict, model_type, model_training_mode):
     """Load model and evaluate with experimental data; verify accuracy (relative RMSE <= threshold)."""
     # Load model
-    mm = ModelManager(config_dict=config_dict, model_type=model_type)
+    mm = ModelManager(
+        config_dict=config_dict,
+        model_type=model_type,
+        model_training_mode=model_training_mode,
+    )
     # Load experimental data
     df_exp, input_names, output_names = load_experimental_data(config_dict)
 
@@ -107,7 +111,7 @@ if __name__ == "__main__":
 
     # Load model and evaluate with experimental data
     try:
-        check_evaluate(config_dict, args.model)
+        check_evaluate(config_dict, args.model, model_training_mode="local")
     except Exception as e:
         print(f"[FAIL] {e}")
         sys.exit(1)


### PR DESCRIPTION
## Overview

Add a local execution mode for ML training, such that the training launched from the dashboard is executed locally instead of on Perlmutter through the Superfacility API.

This assumes the experiment configuration file has a new section of the form
```yaml
execution_mode:
  ml_training: local
  simulation: sfapi
```

## To do

- [x] Review code changes and test end-to-end workflow.
- [x] Define format and naming of the new section in the configuration file.
- [x] Define where the locally-trained model is saved: standard MLflow server.
- [x] Control the execution mode through a new section in the configuration file.
- [x] Rebase after #409.

## Related PRs

- https://github.com/BLAST-AI-ML/synapse-bella-ip2/pull/6
- https://github.com/BLAST-AI-ML/synapse-bella-qed-ip2/pull/6
- https://github.com/BLAST-AI-ML/synapse-bella-acave/pull/6
- https://github.com/BLAST-AI-ML/synapse-bella-staging-injector/pull/13