### PR TITLE
Make sure GP model are stored as CPU-only models in MLflow

### DIFF
--- a/ml/train_model.py
+++ b/ml/train_model.py
@@ -381,7 +381,7 @@ def build_lume_model(
 
     if model_type == "GP":
         # Clear prediction_strategy on each sub-GP before moving to CPU.
-        # It is set during calibration's posterior() call and holds cached CUDA
+        # It is set during training call and holds cached CUDA
         # tensors (e.g. Cholesky factors) that are plain Python attributes, so
         # .cpu() / _apply() won't reach them.
         for sub_gp in model.models:

--- a/ml/train_model.py
+++ b/ml/train_model.py
@@ -380,6 +380,12 @@ def build_lume_model(
         ]
 
     if model_type == "GP":
+        # Clear prediction_strategy on each sub-GP before moving to CPU.
+        # It is set during calibration's posterior() call and holds cached CUDA
+        # tensors (e.g. Cholesky factors) that are plain Python attributes, so
+        # .cpu() / _apply() won't reach them.
+        for sub_gp in model.models:
+            sub_gp.prediction_strategy = None
         return GPModel(
             model=model.cpu(),
             input_variables=input_vars,


### PR DESCRIPTION
## Summary                                                                                                              
                                                                                                                          
  - GP models trained on GPU failed to load on CPU-only machines (e.g. the                                           dashboard's `synapse-gui` environment) with: `Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False`                            
  - Root cause: during calibration, `posterior()` sets a `prediction_strategy` on each sub-GP holding cached CUDA tensors (Cholesky factors). These are plain Python attributes, so gpytorch's `_apply()` does not move them when `.cpu()` is called, and they get serialized as CUDA tensors into MLflow.                                              
  - Fix: clear `prediction_strategy` on each sub-GP before `model.cpu()` in `build_lume_model`. NN/ensemble_NN are unaffected as they have no such cache. 