### PR TITLE
Use consistent c_normcal/o_normcal naming in train_calibration

### DIFF
--- a/ml/Neural_Net_Classes.py
+++ b/ml/Neural_Net_Classes.py
@@ -164,41 +164,48 @@ def train_calibration(
     lr=0.001,
 ):
     """
-    Train per-output affine calibration parameters (weight * prediction + bias)
-    on experimental data. The base model is evaluated at each iteration so that,
-    in the future, input calibration parameters (applied before the model) can
-    also be trained in the same loop.
+    Train per-output affine calibration parameters on experimental data.
+    The base model is evaluated at each iteration so that input calibration
+    parameters (applied before the model) can also be trained in the same loop.
+
+    The learned parameters follow the same convention as `AffineInputTransform`:
+      - coefficients (c_normcal): scale factors (initialized to 1)
+      - offsets (o_normcal): shift values (initialized to 0)
+
+    The calibrated forward pass is:
+      calibrated_input  = (1 / c_normcal_input) * (x - o_normcal_input)
+      calibrated_output = c_normcal_output * model(calibrated_input) + o_normcal_output
 
     Args:
         model: frozen callable that maps exp_inputs -> predictions
         exp_inputs: experimental input tensor
         exp_targets: experimental target values (may contain NaN)
-        n_outputs: number of output dimensions
         num_epochs: number of training epochs
         lr: learning rate
 
     Returns:
-        (cal_weight, cal_bias) as detached tensors
+        (c_normcal_input, o_normcal_input, c_normcal_output, o_normcal_output)
+        as detached tensors
     """
     n_outputs = exp_targets.shape[1]
     n_inputs = exp_inputs.shape[1]
     device = exp_inputs.device
 
-    input_cal_weight = nn.Parameter(
+    c_normcal_input = nn.Parameter(
         torch.ones(n_inputs, dtype=exp_inputs.dtype, device=device)
     )
-    input_cal_bias = nn.Parameter(
+    o_normcal_input = nn.Parameter(
         torch.zeros(n_inputs, dtype=exp_inputs.dtype, device=device)
     )
-    output_cal_weight = nn.Parameter(
+    c_normcal_output = nn.Parameter(
         torch.ones(n_outputs, dtype=exp_inputs.dtype, device=device)
     )
-    output_cal_bias = nn.Parameter(
+    o_normcal_output = nn.Parameter(
         torch.zeros(n_outputs, dtype=exp_inputs.dtype, device=device)
     )
 
     optimizer = optim.Adam(
-        [input_cal_weight, input_cal_bias, output_cal_weight, output_cal_bias], lr=lr
+        [c_normcal_input, o_normcal_input, c_normcal_output, o_normcal_output], lr=lr
     )
     scheduler = ReduceLROnPlateau(
         optimizer, "min", factor=0.5, patience=200, threshold=1e-4
@@ -208,9 +215,9 @@ def train_calibration(
     for epoch in range(num_epochs):
         optimizer.zero_grad()
 
-        calibrated_inputs = (1.0 / input_cal_weight) * (exp_inputs - input_cal_bias)
+        calibrated_inputs = (1.0 / c_normcal_input) * (exp_inputs - o_normcal_input)
         base_predictions = model(calibrated_inputs)
-        calibrated_outputs = output_cal_weight * base_predictions + output_cal_bias
+        calibrated_outputs = c_normcal_output * base_predictions + o_normcal_output
 
         loss = nan_mse_loss(exp_targets, calibrated_outputs)
         loss.backward()
@@ -232,8 +239,8 @@ def train_calibration(
             break
 
     return (
-        input_cal_weight.detach(),
-        input_cal_bias.detach(),
-        output_cal_weight.detach(),
-        output_cal_bias.detach(),
+        c_normcal_input.detach(),
+        o_normcal_input.detach(),
+        c_normcal_output.detach(),
+        o_normcal_output.detach(),
     )

--- a/ml/Neural_Net_Classes.py
+++ b/ml/Neural_Net_Classes.py
@@ -165,8 +165,6 @@ def train_calibration(
 ):
     """
     Train per-output affine calibration parameters on experimental data.
-    The base model is evaluated at each iteration so that input calibration
-    parameters (applied before the model) can also be trained in the same loop.
 
     The learned parameters follow the same convention as `AffineInputTransform`:
       - coefficients (c_normcal): scale factors (initialized to 1)

--- a/ml/train_model.py
+++ b/ml/train_model.py
@@ -335,20 +335,20 @@ def train_calibration_phase(
             return torch.stack([m.forward(x) for m in model]).mean(dim=0)
 
     # Train calibration
-    input_cal_weight, input_cal_bias, output_cal_weight, output_cal_bias = (
+    c_normcal_input, o_normcal_input, c_normcal_output, o_normcal_output = (
         train_calibration(predict_fn, exp_X, exp_y, num_epochs=5000, lr=0.001)
     )
 
     # Build calibration transforms
     input_inferred_normalizedcalibration = AffineInputTransform(
         len(input_names),
-        coefficient=input_cal_weight.cpu(),
-        offset=input_cal_bias.cpu(),
+        coefficient=c_normcal_input.cpu(),
+        offset=o_normcal_input.cpu(),
     )
     output_inferred_normalizedcalibration = AffineInputTransform(
         len(output_names),
-        coefficient=output_cal_weight.cpu(),
-        offset=output_cal_bias.cpu(),
+        coefficient=c_normcal_output.cpu(),
+        offset=o_normcal_output.cpu(),
     )
     return input_inferred_normalizedcalibration, output_inferred_normalizedcalibration
 


### PR DESCRIPTION
## Summary

In `train_calibration`, the learnable coefficient are named "weights" and "biases", but in `train_model.py`, they are called coefficients and offsets (and denoted as `c_normcal` and `o_normcal`).

This PR fixes this discrepancy and makes it clear that these are the same variables:
- Renames the learnable parameters in `train_calibration` (`Neural_Net_Classes.py`) from `input_cal_weight`/`input_cal_bias`/`output_cal_weight`/`output_cal_bias` to `c_normcal_input`/`o_normcal_input`/`c_normcal_output`/`o_normcal_output`
- Updates the unpacking in `train_calibration_phase` (`train_model.py`) to use the same names, making it clear these map directly to the `coefficient`/`offset` fields of `AffineInputTransform`
- Expands the docstring to document the calibrated forward pass and the renamed return tuple

🤖 Generated with [Claude Code](https://claude.com/claude-code)