### PR TITLE
[WIP] check_model.py: test model on simulation data too

### DIFF
--- a/dashboard/calibration_manager.py
+++ b/dashboard/calibration_manager.py
@@ -4,28 +4,6 @@ from error_manager import add_error
 import copy
 
 
-def populate_inferred_calibration(variables, alpha_values, beta_values):
-    """
-    Write alpha_inferred / beta_inferred into state.simulation_calibration for each
-    variable that has a matching 'depends_on' entry.
-
-    variables: dict mapping config key -> variable dict with a 'name' field
-               (i.e. config_dict['inputs'] or config_dict['outputs'])
-    alpha_values, beta_values: tensors or lists, one value per variable (same order)
-    """
-    depends_on_to_key = {
-        v["depends_on"]: k
-        for k, v in state.simulation_calibration.items()
-        if "depends_on" in v
-    }
-    for i, var_info in enumerate(variables.values()):
-        exp_name = var_info["name"]
-        if exp_name in depends_on_to_key:
-            key = depends_on_to_key[exp_name]
-            state.simulation_calibration[key]["alpha_inferred"] = float(alpha_values[i])
-            state.simulation_calibration[key]["beta_inferred"] = float(beta_values[i])
-
-
 class SimulationCalibrationManager:
     def __init__(self, simulation_calibration):
         state.simulation_calibration = copy.deepcopy(simulation_calibration)

--- a/dashboard/calibration_manager.py
+++ b/dashboard/calibration_manager.py
@@ -4,6 +4,28 @@ from error_manager import add_error
 import copy
 
 
+def populate_inferred_calibration(variables, alpha_values, beta_values):
+    """
+    Write alpha_inferred / beta_inferred into state.simulation_calibration for each
+    variable that has a matching 'depends_on' entry.
+
+    variables: dict mapping config key -> variable dict with a 'name' field
+               (i.e. config_dict['inputs'] or config_dict['outputs'])
+    alpha_values, beta_values: tensors or lists, one value per variable (same order)
+    """
+    depends_on_to_key = {
+        v["depends_on"]: k
+        for k, v in state.simulation_calibration.items()
+        if "depends_on" in v
+    }
+    for i, var_info in enumerate(variables.values()):
+        exp_name = var_info["name"]
+        if exp_name in depends_on_to_key:
+            key = depends_on_to_key[exp_name]
+            state.simulation_calibration[key]["alpha_inferred"] = float(alpha_values[i])
+            state.simulation_calibration[key]["beta_inferred"] = float(beta_values[i])
+
+
 class SimulationCalibrationManager:
     def __init__(self, simulation_calibration):
         state.simulation_calibration = copy.deepcopy(simulation_calibration)

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -152,7 +152,11 @@ class ModelManager:
             value.pop("beta_inferred", None)
 
         # Input calibration
-        input_transformers = self.__model.input_transformers
+        # For ensemble_NN, transformers live on each inner TorchModel (not on NNEnsemble itself)
+        if self.__model_type == "ensemble_NN":
+            input_transformers = self.__model.models[0].input_transformers
+        else:
+            input_transformers = self.__model.input_transformers
         assert len(input_transformers) == 2, (
             f"Expected exactly 2 input transformers (calibration + normalization), "
             f"but got {len(input_transformers)}."
@@ -167,7 +171,11 @@ class ModelManager:
             state.simulation_calibration[key]["beta_inferred"] = float(beta_inferred[i])
 
         # Output calibration
-        output_transformers = self.__model.output_transformers
+        # For ensemble_NN, transformers live on each inner TorchModel (not on NNEnsemble itself)
+        if self.__model_type == "ensemble_NN":
+            output_transformers = self.__model.models[0].output_transformers
+        else:
+            output_transformers = self.__model.output_transformers
         assert len(output_transformers) == 2, (
             f"Expected exactly 2 output transformers (normalization + calibration), "
             f"but got {len(output_transformers)}."

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -10,6 +10,7 @@ from sfapi_client import AsyncClient
 from sfapi_client.compute import Machine
 from trame.widgets import vuetify3 as vuetify
 from utils import timer, load_config_dict, create_date_filter
+from calibration_manager import populate_inferred_calibration
 from error_manager import add_error
 from sfapi_manager import monitor_sfapi_job
 from state_manager import state
@@ -162,11 +163,7 @@ class ModelManager:
         input_inferred_calibration = input_transformers[0]
         alpha_inferred = 1.0 / input_inferred_calibration.coefficient
         beta_inferred = input_inferred_calibration.offset
-        for i, key in enumerate(input_variables.keys()):
-            state.simulation_calibration[key]["alpha_inferred"] = float(
-                alpha_inferred[i]
-            )
-            state.simulation_calibration[key]["beta_inferred"] = float(beta_inferred[i])
+        populate_inferred_calibration(input_variables, alpha_inferred, beta_inferred)
 
         # Output calibration
         # For ensemble_NN, transformers live on each inner TorchModel (not on NNEnsemble itself)
@@ -181,11 +178,7 @@ class ModelManager:
         output_inferred_calibration = output_transformers[-1]
         alpha_inferred = 1.0 / output_inferred_calibration.coefficient
         beta_inferred = output_inferred_calibration.offset
-        for i, key in enumerate(output_variables.keys()):
-            state.simulation_calibration[key]["alpha_inferred"] = float(
-                alpha_inferred[i]
-            )
-            state.simulation_calibration[key]["beta_inferred"] = float(beta_inferred[i])
+        populate_inferred_calibration(output_variables, alpha_inferred, beta_inferred)
         # Notify Trame that the dict was modified in-place, so the UI updates
         state.dirty("simulation_calibration")
 

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -10,7 +10,6 @@ from sfapi_client import AsyncClient
 from sfapi_client.compute import Machine
 from trame.widgets import vuetify3 as vuetify
 from utils import timer, load_config_dict, create_date_filter
-from calibration_manager import populate_inferred_calibration
 from error_manager import add_error
 from sfapi_manager import monitor_sfapi_job
 from state_manager import state
@@ -163,7 +162,11 @@ class ModelManager:
         input_inferred_calibration = input_transformers[0]
         alpha_inferred = 1.0 / input_inferred_calibration.coefficient
         beta_inferred = input_inferred_calibration.offset
-        populate_inferred_calibration(input_variables, alpha_inferred, beta_inferred)
+        for i, key in enumerate(input_variables.keys()):
+            state.simulation_calibration[key]["alpha_inferred"] = float(
+                alpha_inferred[i]
+            )
+            state.simulation_calibration[key]["beta_inferred"] = float(beta_inferred[i])
 
         # Output calibration
         # For ensemble_NN, transformers live on each inner TorchModel (not on NNEnsemble itself)
@@ -178,7 +181,11 @@ class ModelManager:
         output_inferred_calibration = output_transformers[-1]
         alpha_inferred = 1.0 / output_inferred_calibration.coefficient
         beta_inferred = output_inferred_calibration.offset
-        populate_inferred_calibration(output_variables, alpha_inferred, beta_inferred)
+        for i, key in enumerate(output_variables.keys()):
+            state.simulation_calibration[key]["alpha_inferred"] = float(
+                alpha_inferred[i]
+            )
+            state.simulation_calibration[key]["beta_inferred"] = float(beta_inferred[i])
         # Notify Trame that the dict was modified in-place, so the UI updates
         state.dirty("simulation_calibration")
 

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -98,11 +98,9 @@ class ModelManager:
             if model_type not in ("NN", "ensemble_NN", "GP"):
                 raise ValueError(f"Unsupported model type: {model_type}")
             # Populate inferred calibration in physics units for GUI
-            # (only meaningful inside the dashboard where state.simulation_calibration is set)
-            if state.simulation_calibration is not None:
-                self.populate_inferred_calibration(
-                    config_dict["inputs"], config_dict["outputs"]
-                )
+            self.populate_inferred_calibration(
+                config_dict["inputs"], config_dict["outputs"]
+            )
         except Exception as e:
             title = f"Unable to load model {model_type}"
             msg = f"Error occurred when loading model from MLflow: {e}"

--- a/tests/check_model.py
+++ b/tests/check_model.py
@@ -17,46 +17,38 @@ DASHBOARD_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "dashboard"
 )  # similar to "cd ../dashboard"
 sys.path.insert(0, DASHBOARD_DIR)
+from calibration_manager import SimulationCalibrationManager  # noqa: E402
 from model_manager import ModelManager  # noqa: E402
-from utils import load_database, load_data  # noqa: E402
+from state_manager import state  # noqa: E402
+from utils import load_database, load_data as _load_data  # noqa: E402
 
 
 MODEL_TYPES = ["GP", "NN", "ensemble_NN"]
 ACCURACY_TOLERANCE = 0.80
 
 
-def load_experimental_data(config_dict):
-    """Fetch all experimental points from the database."""
+def load_data(config_dict):
+    """Fetch all experimental and simulation points from the database."""
     input_names = [v["name"] for v in config_dict["inputs"].values()]
     output_names = [v["name"] for v in config_dict["outputs"].values()]
 
     db = load_database(config_dict)
-    exp_data, _ = load_data(db, config_dict["experiment"])
+    exp_data, sim_data = _load_data(db, config_dict["experiment"])
 
-    return exp_data, input_names, output_names
+    return exp_data, sim_data, input_names, output_names
 
 
-def check_evaluate(config_dict, model_type):
-    """Load model and evaluate with experimental data; verify accuracy (relative RMSE <= threshold)."""
-    # Load model
-    mm = ModelManager(config_dict=config_dict, model_type=model_type)
-    # Load experimental data
-    df_exp, input_names, output_names = load_experimental_data(config_dict)
+def check_accuracy(mm, df, input_names, output_names, label):
+    """Evaluate model on *df* and return True if all outputs pass the accuracy threshold."""
+    if len(df) == 0:
+        print(f"[SKIP] No {label} data available; skipping accuracy check.")
+        return True
 
-    # Skip accuracy check if no experimental data available
-    if len(df_exp) == 0:
-        print(
-            f"[SKIP] No experimental data available for {config_dict['experiment']}; skipping accuracy check."
-        )
-        return
+    inputs = {n: torch.tensor(df[n].values) for n in input_names}
 
-    # Convert input to the format expected by the model manager
-    inputs = {n: torch.tensor(df_exp[n].values) for n in input_names}
-
-    # Check accuracy
     all_passed = True
     for output_name in output_names:
-        actual = torch.tensor(df_exp[output_name].values)
+        actual = torch.tensor(df[output_name].values)
         if actual.isnan().all():
             print(
                 f"  [SKIP] Output '{output_name}': all actual values are NaN; skipping."
@@ -75,8 +67,34 @@ def check_evaluate(config_dict, model_type):
         print(
             f"  [{status}] Output '{output_name}': relative RMSE = {rmse:.1%} (tolerance {ACCURACY_TOLERANCE:.0%})"
         )
+    return all_passed
 
-    if not all_passed:
+
+def check_evaluate(config_dict, model_type):
+    """Load model and evaluate with experimental and simulation data; verify accuracy."""
+    # Set up calibration so ModelManager can populate inferred values
+    simulation_calibration = config_dict.get("simulation_calibration", {})
+    cal_manager = SimulationCalibrationManager(simulation_calibration)
+    state.use_inferred_calibration = True
+
+    # Load model (populates inferred calibration in state.simulation_calibration)
+    mm = ModelManager(config_dict=config_dict, model_type=model_type)
+
+    # Load experimental and simulation data
+    df_exp, df_sim, input_names, output_names = load_data(config_dict)
+
+    # Check accuracy on experimental data
+    print("Checking experimental data...")
+    exp_passed = check_accuracy(mm, df_exp, input_names, output_names, "experimental")
+
+    # Convert simulation data to experimental units using inferred calibration
+    cal_manager.convert_sim_to_exp(df_sim)
+
+    # Check accuracy on simulation data
+    print("Checking simulation data...")
+    sim_passed = check_accuracy(mm, df_sim, input_names, output_names, "simulation")
+
+    if not (exp_passed and sim_passed):
         raise RuntimeError(
             f"Accuracy check failed: relative RMSE exceeded {ACCURACY_TOLERANCE:.0%} for one or more outputs."
         )
@@ -105,7 +123,7 @@ if __name__ == "__main__":
         config_dict = yaml.safe_load(f)
     print(f"Experiment: {config_dict['experiment']}")
 
-    # Load model and evaluate with experimental data
+    # Load model and evaluate with experimental and simulation data
     try:
         check_evaluate(config_dict, args.model)
     except Exception as e:


### PR DESCRIPTION
## Summary

- **Extended `check_model.py` to test accuracy on simulation data.** After loading the model, simulation points are converted to experimental units using the inferred calibration (via `cal_manager.convert_sim_to_exp`), then evaluated against the model. Both experimental and simulation datasets must pass the relative RMSE tolerance for the test to succeed.

- **Fixed `AttributeError` when loading `ensemble_NN` models.** `NNEnsemble` does not expose `input_transformers`/`output_transformers` directly — those live on each inner `TorchModel`. `ModelManager` now accesses them via `models[0]` for the ensemble case.