### PR TITLE
Fix AttributeError when loading ensemble_NN in ModelManager

### DIFF
--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -152,7 +152,11 @@ class ModelManager:
             value.pop("beta_inferred", None)
 
         # Input calibration
-        input_transformers = self.__model.input_transformers
+        # For ensemble_NN, transformers live on each inner TorchModel (not on NNEnsemble itself)
+        if self.__model_type == "ensemble_NN":
+            input_transformers = self.__model.models[0].input_transformers
+        else:
+            input_transformers = self.__model.input_transformers
         assert len(input_transformers) == 2, (
             f"Expected exactly 2 input transformers (calibration + normalization), "
             f"but got {len(input_transformers)}."
@@ -167,7 +171,11 @@ class ModelManager:
             state.simulation_calibration[key]["beta_inferred"] = float(beta_inferred[i])
 
         # Output calibration
-        output_transformers = self.__model.output_transformers
+        # For ensemble_NN, transformers live on each inner TorchModel (not on NNEnsemble itself)
+        if self.__model_type == "ensemble_NN":
+            output_transformers = self.__model.models[0].output_transformers
+        else:
+            output_transformers = self.__model.output_transformers
         assert len(output_transformers) == 2, (
             f"Expected exactly 2 output transformers (normalization + calibration), "
             f"but got {len(output_transformers)}."


### PR DESCRIPTION
## Problem

`ModelManager.populate_inferred_calibration()` accessed `self.__model.input_transformers` and `self.__model.output_transformers` directly. This works for `GP` and `NN` models, but fails for `ensemble_NN` with:

```
'NNEnsemble' object has no attribute 'input_transformers'
```

The root cause: `NNEnsemble` (from `lume_model`) does not define `input_transformers`/`output_transformers` at the ensemble level. Those attributes live on each inner `TorchModel`. The `NNEnsemble` was constructed in `train_model.py` with transformers passed only to the inner models, not to the wrapper.

## Fix

When the model type is `ensemble_NN`, read the transformers from `self.__model.models[0]` instead. All inner models share the same transformers, so using the first one is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)