### PR TITLE
Fix KeyError when populating inferred calibration for output variables

### DIFF
--- a/dashboard/calibration_manager.py
+++ b/dashboard/calibration_manager.py
@@ -4,7 +4,7 @@ from error_manager import add_error
 import copy
 
 
-def write_inferred_calibration(variables, alpha_values, beta_values):
+def build_inferred_calibration(variables, alpha_values, beta_values):
     """
     Write alpha_inferred / beta_inferred into state.simulation_calibration for each
     variable that has a matching 'depends_on' entry.
@@ -13,17 +13,17 @@ def write_inferred_calibration(variables, alpha_values, beta_values):
                (i.e. config_dict['inputs'] or config_dict['outputs'])
     alpha_values, beta_values: tensors or lists, one value per variable (same order)
     """
-    depends_on_to_key = {
-        v["depends_on"]: k
-        for k, v in state.simulation_calibration.items()
-        if "depends_on" in v
+    depends_on_lookup = {
+        entry["depends_on"]: entry
+        for entry in state.simulation_calibration.values()
+        if "depends_on" in entry
     }
     for i, var_info in enumerate(variables.values()):
         exp_name = var_info["name"]
-        if exp_name in depends_on_to_key:
-            key = depends_on_to_key[exp_name]
-            state.simulation_calibration[key]["alpha_inferred"] = float(alpha_values[i])
-            state.simulation_calibration[key]["beta_inferred"] = float(beta_values[i])
+        if exp_name in depends_on_lookup:
+            entry = depends_on_lookup[exp_name]
+            entry["alpha_inferred"] = float(alpha_values[i])
+            entry["beta_inferred"] = float(beta_values[i])
 
 
 class SimulationCalibrationManager:

--- a/dashboard/calibration_manager.py
+++ b/dashboard/calibration_manager.py
@@ -4,6 +4,28 @@ from error_manager import add_error
 import copy
 
 
+def write_inferred_calibration(variables, alpha_values, beta_values):
+    """
+    Write alpha_inferred / beta_inferred into state.simulation_calibration for each
+    variable that has a matching 'depends_on' entry.
+
+    variables: dict mapping config key -> variable dict with a 'name' field
+               (i.e. config_dict['inputs'] or config_dict['outputs'])
+    alpha_values, beta_values: tensors or lists, one value per variable (same order)
+    """
+    depends_on_to_key = {
+        v["depends_on"]: k
+        for k, v in state.simulation_calibration.items()
+        if "depends_on" in v
+    }
+    for i, var_info in enumerate(variables.values()):
+        exp_name = var_info["name"]
+        if exp_name in depends_on_to_key:
+            key = depends_on_to_key[exp_name]
+            state.simulation_calibration[key]["alpha_inferred"] = float(alpha_values[i])
+            state.simulation_calibration[key]["beta_inferred"] = float(beta_values[i])
+
+
 class SimulationCalibrationManager:
     def __init__(self, simulation_calibration):
         state.simulation_calibration = copy.deepcopy(simulation_calibration)

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -10,6 +10,7 @@ from sfapi_client import AsyncClient
 from sfapi_client.compute import Machine
 from trame.widgets import vuetify3 as vuetify
 from utils import timer, load_config_dict, create_date_filter
+from calibration_manager import write_inferred_calibration
 from error_manager import add_error
 from sfapi_manager import monitor_sfapi_job
 from state_manager import state
@@ -160,11 +161,7 @@ class ModelManager:
         input_inferred_calibration = input_transformers[0]
         alpha_inferred = 1.0 / input_inferred_calibration.coefficient
         beta_inferred = input_inferred_calibration.offset
-        for i, key in enumerate(input_variables.keys()):
-            state.simulation_calibration[key]["alpha_inferred"] = float(
-                alpha_inferred[i]
-            )
-            state.simulation_calibration[key]["beta_inferred"] = float(beta_inferred[i])
+        write_inferred_calibration(input_variables, alpha_inferred, beta_inferred)
 
         # Output calibration
         output_transformers = self.__model.output_transformers
@@ -175,11 +172,7 @@ class ModelManager:
         output_inferred_calibration = output_transformers[-1]
         alpha_inferred = 1.0 / output_inferred_calibration.coefficient
         beta_inferred = output_inferred_calibration.offset
-        for i, key in enumerate(output_variables.keys()):
-            state.simulation_calibration[key]["alpha_inferred"] = float(
-                alpha_inferred[i]
-            )
-            state.simulation_calibration[key]["beta_inferred"] = float(beta_inferred[i])
+        write_inferred_calibration(output_variables, alpha_inferred, beta_inferred)
         # Notify Trame that the dict was modified in-place, so the UI updates
         state.dirty("simulation_calibration")
 

--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -10,7 +10,7 @@ from sfapi_client import AsyncClient
 from sfapi_client.compute import Machine
 from trame.widgets import vuetify3 as vuetify
 from utils import timer, load_config_dict, create_date_filter
-from calibration_manager import write_inferred_calibration
+from calibration_manager import build_inferred_calibration
 from error_manager import add_error
 from sfapi_manager import monitor_sfapi_job
 from state_manager import state
@@ -165,7 +165,7 @@ class ModelManager:
         input_inferred_calibration = input_transformers[0]
         alpha_inferred = 1.0 / input_inferred_calibration.coefficient
         beta_inferred = input_inferred_calibration.offset
-        write_inferred_calibration(input_variables, alpha_inferred, beta_inferred)
+        build_inferred_calibration(input_variables, alpha_inferred, beta_inferred)
 
         # Output calibration
         # For ensemble_NN, transformers live on each inner TorchModel (not on NNEnsemble itself)
@@ -180,7 +180,7 @@ class ModelManager:
         output_inferred_calibration = output_transformers[-1]
         alpha_inferred = 1.0 / output_inferred_calibration.coefficient
         beta_inferred = output_inferred_calibration.offset
-        write_inferred_calibration(output_variables, alpha_inferred, beta_inferred)
+        build_inferred_calibration(output_variables, alpha_inferred, beta_inferred)
         # Notify Trame that the dict was modified in-place, so the UI updates
         state.dirty("simulation_calibration")
 


### PR DESCRIPTION
## Summary

`ModelManager.populate_inferred_calibration` was writing inferred values into `state.simulation_calibration` using `config_dict["outputs"]` keys (`output1`, `output2`, …). These keys don't exist in `simulation_calibration`, which uses its own scheme (calibrated outputs appear as e.g. `input6`/`input7`, and uncalibrated outputs have no entry at all), causing a `KeyError` on model load, for instance for `bella-staging-injector`.

The PR fixes the issue by introducing a function `build_inferred_calibration` function that reads the `depends_on` entry of the YAML file to build the correct correspondance between simulation and experimental variable. `ModelManager` now calls this helper instead of the broken direct-key loops.

`build_inferred_calibration` is intentionally structured to mirror `build_guess_calibration` in `train_model.py`: both invert the `simulation_calibration` config into a `depends_on_lookup` dict and iterate over variables by experimental name.