### PR TITLE
Rename experiment/models in MLflow

### DIFF
--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -86,7 +86,7 @@ class ModelManager:
             enable_amsc_x_api_key(config_dict)
 
         experiment = config_dict["experiment"]
-        model_name = f"{experiment}_{model_type}"
+        model_name = f"synapse-{experiment}_{model_type}"
 
         try:
             # Download model from MLflow server

--- a/ml/train_model.py
+++ b/ml/train_model.py
@@ -503,11 +503,11 @@ def enable_amsc_x_api_key(config_dict):
 def register_model_to_mlflow(model, model_type, experiment, config_dict):
     """Register the trained model to MLflow (tracking URI from config)."""
     tracking_uri = config_dict["mlflow"]["tracking_uri"]
-    model_name = f"{experiment}_{model_type}"
+    model_name = f"synapse-{experiment}_{model_type}"
 
     try:
         mlflow.set_tracking_uri(tracking_uri)
-        mlflow.set_experiment(experiment)
+        mlflow.set_experiment(f"synapse-{experiment}")
 
         model.register_to_mlflow(
             artifact_path=f"{model_name}_run",


### PR DESCRIPTION
The experiments and models in MLflow will be named with `synapse-` at the beginning.
e.g. `synapse-bella-ip2` instead of `bella-ip2`.