### PR TITLE
Remove redundant function initialize_sfapi

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -11,7 +11,7 @@ from outputs_manager import OutputManager
 from optimization_manager import OptimizationManager
 from parameters_manager import ParametersManager
 from calibration_manager import SimulationCalibrationManager
-from sfapi_manager import initialize_sfapi, load_sfapi_card
+from sfapi_manager import load_sfapi_card
 from state_manager import server, state, ctrl, initialize_state
 from error_manager import error_panel, add_error
 from utils import (
@@ -477,8 +477,6 @@ def gui_setup():
 if __name__ == "__main__":
     # initialize state variables needed at startup
     initialize_state()
-    # initialize Superfacility API
-    initialize_sfapi()
     # update for the first time
     update()
     # start server

--- a/dashboard/sfapi_manager.py
+++ b/dashboard/sfapi_manager.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import os
 from sfapi_client import Client
 from sfapi_client.compute import Machine
 from trame.widgets import vuetify3 as vuetify
@@ -34,26 +33,6 @@ def parse_sfapi_key(key_str):
     state.sfapi_client_id = key_lines.pop(0).rstrip()
     # set the key from the remaining lines in the file
     state.sfapi_key = "".join(key_lines)
-
-
-def initialize_sfapi():
-    print("Initializing Superfacility API...")
-    # look for a key file in the current directory
-    key_path = os.path.join(os.getcwd(), "priv_key.pem")
-    if os.path.isfile(key_path):
-        try:
-            with Client(key=key_path) as client:
-                # store the whole content of the key file in a string
-                key_str = client._secret
-                # store the client ID and key in the respective state variables
-                parse_sfapi_key(key_str)
-                # update Superfacility API info
-                update_sfapi_info()
-        except Exception as e:
-            title = "Unable to initialize the Superfacility API connection"
-            msg = f"Error occurred when initializing the Superfacility API connection: {e}"
-            add_error(title, msg)
-            print(msg)
 
 
 def update_sfapi_info():


### PR DESCRIPTION
## Overview

While working on #428, I noticed that the function `initialize_sfapi` is kind of redundant. It is a manual initialization at startup that has an effect only if there is a private key file saved in the current working directory, which I think is an ad hoc setup that isn't frequent. Unless I'm missing something, I think removing the function is safe and reduces the amount of code to maintain.