### PR TITLE
Improve style of parameters card

### DIFF
--- a/dashboard/parameters_manager.py
+++ b/dashboard/parameters_manager.py
@@ -227,27 +227,30 @@ class ParametersManager:
                                         change="flushState('parameters_show_all')",
                                         label="Show all",
                                     )
-                        with vuetify.VRow(align="center"):
-                            with vuetify.VCol(cols=6):
-                                with vuetify.VRow():
-                                    with vuetify.VCol():
-                                        vuetify.VBtn(
-                                            "Reset",
-                                            click=self.reset,
-                                            style="text-transform: none",
-                                        )
-                                    with vuetify.VCol():
-                                        vuetify.VBtn(
-                                            "Simulate",
-                                            click=self.simulation_trigger,
-                                            disabled=(
-                                                "simulation_running || perlmutter_status != 'active' || !simulatable",
-                                            ),
-                                            style="text-transform: none;",
-                                        )
-                            with vuetify.VCol(cols=6):
+                        with vuetify.VRow():
+                            with vuetify.VCol():
                                 vuetify.VTextField(
                                     v_model_number=("simulation_running_status",),
                                     label="Simulation status",
                                     readonly=True,
+                                    dense=True,
+                                    hide_details=True,
+                                )
+                        with vuetify.VRow():
+                            with vuetify.VCol(cols=6):
+                                vuetify.VBtn(
+                                    "Reset",
+                                    click=self.reset,
+                                    block=True,
+                                    style="text-transform: none",
+                                )
+                            with vuetify.VCol(cols=6):
+                                vuetify.VBtn(
+                                    "Simulate",
+                                    click=self.simulation_trigger,
+                                    disabled=(
+                                        "simulation_running || perlmutter_status != 'active' || !simulatable",
+                                    ),
+                                    block=True,
+                                    style="text-transform: none",
                                 )


### PR DESCRIPTION
## Overview

Minor style changes extracted from #439.

## Before

<p align="center">
<img width="500" alt="Screenshot from 2026-05-08 13-22-48" src="https://github.com/user-attachments/assets/84269f16-07c0-477e-8ec0-a1583e2c1f12" />
</p>

## After

<p align="center">
<img width="500" alt="Screenshot from 2026-05-08 13-19-34" src="https://github.com/user-attachments/assets/8861db9f-2387-4d8d-be86-b3f96d9f628d" />
</p>

## Diff without whitespace

```diff
diff --git a/dashboard/parameters_manager.py b/dashboard/parameters_manager.py
index 9cfc5a5..7fe3e39 100644
--- a/dashboard/parameters_manager.py
+++ b/dashboard/parameters_manager.py
@@ -227,27 +227,30 @@ class ParametersManager:
                                         change="flushState('parameters_show_all')",
                                         label="Show all",
                                     )
-                        with vuetify.VRow(align="center"):
-                            with vuetify.VCol(cols=6):
                         with vuetify.VRow():
                             with vuetify.VCol():
+                                vuetify.VTextField(
+                                    v_model_number=("simulation_running_status",),
+                                    label="Simulation status",
+                                    readonly=True,
+                                    dense=True,
+                                    hide_details=True,
+                                )
+                        with vuetify.VRow():
+                            with vuetify.VCol(cols=6):
                                 vuetify.VBtn(
                                     "Reset",
                                     click=self.reset,
+                                    block=True,
                                     style="text-transform: none",
                                 )
-                                    with vuetify.VCol():
+                            with vuetify.VCol(cols=6):
                                 vuetify.VBtn(
                                     "Simulate",
                                     click=self.simulation_trigger,
                                     disabled=(
                                         "simulation_running || perlmutter_status != 'active' || !simulatable",
                                     ),
-                                            style="text-transform: none;",
-                                        )
-                            with vuetify.VCol(cols=6):
-                                vuetify.VTextField(
-                                    v_model_number=("simulation_running_status",),
-                                    label="Simulation status",
-                                    readonly=True,
+                                    block=True,
+                                    style="text-transform: none",
                                 )
```