### PR TITLE
Improve style of optimization card

### DIFF
--- a/dashboard/optimization_manager.py
+++ b/dashboard/optimization_manager.py
@@ -87,18 +87,22 @@ class OptimizationManager:
                                 label="Optimization target",
                                 items=(state.output_variables,),
                                 dense=True,
+                                hide_details=True,
                             )
+                    with vuetify.VRow():
                         with vuetify.VCol():
                             vuetify.VSelect(
                                 v_model=("optimization_type",),
                                 label="Optimization type",
                                 items=(optimization_type_list,),
                                 dense=True,
+                                hide_details=True,
                             )
                     with vuetify.VRow():
                         with vuetify.VCol():
                             vuetify.VBtn(
                                 "Optimize",
+                                block=True,
                                 click=self.optimize_trigger,
                                 style="text-transform: none",
                             )


### PR DESCRIPTION
## Overview

Minor style changes extracted from #439.

## Before

<p align="center">
<img width="500" alt="Screenshot from 2026-05-08 13-39-56" src="https://github.com/user-attachments/assets/9c2813bf-ce2e-4c7d-8895-1bddc3f212d9" />
</p>

## After

<p align="center">
<img width="500" alt="Screenshot from 2026-05-08 13-38-50" src="https://github.com/user-attachments/assets/dd686ede-e621-422b-8f0b-f373a615e13e" />
</p>