### PR TITLE
Read password from stdin for podman-hpc login

### DIFF
--- a/ml/training_pm.sbatch
+++ b/ml/training_pm.sbatch
@@ -25,7 +25,7 @@ REGISTRY_NAME="registry.nersc.gov"
 IMAGE_NAME="m558/superfacility/synapse-ml"
 IMAGE_VERSION="latest"
 
-podman-hpc login --username "${REGISTRY_USER}" --password "${REGISTRY_PASSWORD}" ${REGISTRY_NAME}
+echo "${REGISTRY_PASSWORD}" | podman-hpc login --username "${REGISTRY_USER}" --password-stdin "${REGISTRY_NAME}"
 # As the local image, we use the digest id.
 #   podman-hpc lists to entries with the same digest id,
 #   one local and one migrated (read-write and read-only).


### PR DESCRIPTION
## Overview

Small change extracted from #432, which in turn was extracted from #428, now replaced by #439.

Avoid exposing `REGISTRY_PASSWORD` in the process list (`ps` output) by piping it via `stdin` instead of passing it as a `--password` argument. 

Note that all documented examples at https://docs.podman.io/en/stable/markdown/podman-login.1.html (`podman` instead of `podman-hpc`) use `--password-stdin`.

## Notes

The original suggestion in #432 and #428 had `printf '%s\n'` instead of `echo` to guard against passwords starting with `-n`, `-e`, or containing backslash sequences, but it should be robust enough to use `echo` in this case.
