### PR TITLE
Improve style of Superfacility API card

### DIFF
--- a/dashboard/sfapi_manager.py
+++ b/dashboard/sfapi_manager.py
@@ -114,12 +114,17 @@ def load_sfapi_card():
             with vuetify.VCardText():
                 # row with component to upload input file
                 with vuetify.VRow():
-                    vuetify.VFileInput(
-                        v_model=("sfapi_key_dict",),
-                        label="Key File (pem format, must include client ID in first line)",
-                        accept=".pem",
-                        __properties=["accept"],
-                    )
+                    with vuetify.VCol():
+                        vuetify.VFileInput(
+                            v_model=("sfapi_key_dict",),
+                            label="Key File (pem format, must include client ID in first line)",
+                            accept=".pem",
+                            prepend_icon="",
+                            prepend_inner_icon="mdi-paperclip",
+                            hide_details=True,
+                            style="cursor: pointer",
+                            __properties=["accept"],
+                        )
                 # row with text field to display key expiration date
                 with vuetify.VRow():
                     with vuetify.VCol():
@@ -127,6 +132,7 @@ def load_sfapi_card():
                             v_model=("sfapi_key_expiration",),
                             label="Key Expiration (if expired or unavailable, please upload a valid key)",
                             readonly=True,
+                            hide_details=True,
                         )
                 # row with text field to display Perlmutter status
                 with vuetify.VRow():
@@ -135,4 +141,5 @@ def load_sfapi_card():
                             v_model=("perlmutter_description",),
                             label="Perlmutter Status",
                             readonly=True,
+                            hide_details=True,
                         )


### PR DESCRIPTION
## Overview

Minor style changes extracted from #439.

## Before

<p align="center">
<img width="500" alt="Screenshot from 2026-05-11 11-07-40" src="https://github.com/user-attachments/assets/d4479274-7e49-4fe5-8006-0128175ad6f0" />
</p>

## After

<p align="center">
<img width="500" alt="Screenshot from 2026-05-11 11-22-30" src="https://github.com/user-attachments/assets/a558f854-dbb0-4e12-a434-5d9620aa6622" />
</p>

## Diff without whitespace

```diff
diff --git a/dashboard/sfapi_manager.py b/dashboard/sfapi_manager.py
index b3dd58d..362881c 100644
--- a/dashboard/sfapi_manager.py
+++ b/dashboard/sfapi_manager.py
@@ -114,10 +114,15 @@ def load_sfapi_card():
             with vuetify.VCardText():
                 # row with component to upload input file
                 with vuetify.VRow():
+                    with vuetify.VCol():
                         vuetify.VFileInput(
                             v_model=("sfapi_key_dict",),
                             label="Key File (pem format, must include client ID in first line)",
                             accept=".pem",
+                            prepend_icon="",
+                            prepend_inner_icon="mdi-paperclip",
+                            hide_details=True,
+                            style="cursor: pointer",
                             __properties=["accept"],
                         )
                 # row with text field to display key expiration date
@@ -127,6 +132,7 @@ def load_sfapi_card():
                             v_model=("sfapi_key_expiration",),
                             label="Key Expiration (if expired or unavailable, please upload a valid key)",
                             readonly=True,
+                            hide_details=True,
                         )
                 # row with text field to display Perlmutter status
                 with vuetify.VRow():
@@ -135,4 +141,5 @@ def load_sfapi_card():
                             v_model=("perlmutter_description",),
                             label="Perlmutter Status",
                             readonly=True,
+                            hide_details=True,
                         )
```