### PR TITLE
Rename NERSC route to include more backends

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -55,7 +55,7 @@ def update(
     reset_calibration=True,
     reset_plots=True,
     reset_gui_route_home=True,
-    reset_gui_route_nersc=True,
+    reset_gui_route_hpc=True,
     reset_gui_route_chat=True,
     reset_gui_layout=True,
     preloaded_model_manager=None,
@@ -108,9 +108,9 @@ def update(
     # reset GUI home route
     if reset_gui_route_home:
         home_route()
-    # reset GUI NERSC route
-    if reset_gui_route_nersc:
-        nersc_route()
+    # reset GUI HPC route
+    if reset_gui_route_hpc:
+        hpc_route()
     # reset GUI chat route
     if reset_gui_route_chat:
         chat_route()
@@ -222,7 +222,7 @@ def reset(**kwargs):
                 reset_calibration=True,
                 reset_plots=True,
                 reset_gui_route_home=True,
-                reset_gui_route_nersc=False,
+                reset_gui_route_hpc=False,
                 reset_gui_route_chat=False,
                 reset_gui_layout=False,
             )
@@ -240,7 +240,7 @@ def reset(**kwargs):
                 reset_calibration=False,
                 reset_plots=True,
                 reset_gui_route_home=True,
-                reset_gui_route_nersc=False,
+                reset_gui_route_hpc=False,
                 reset_gui_route_chat=False,
                 reset_gui_layout=False,
             )
@@ -264,7 +264,7 @@ def reset(**kwargs):
                 reset_calibration=False,
                 reset_plots=True,
                 reset_gui_route_home=False,
-                reset_gui_route_nersc=False,
+                reset_gui_route_hpc=False,
                 reset_gui_route_chat=False,
                 reset_gui_layout=False,
             )
@@ -433,13 +433,13 @@ def home_route():
                             ctrl.figure_update = figure.update
 
 
-# NERSC route
-def nersc_route():
-    print("Setting GUI NERSC route...")
-    with RouterViewLayout(server, "/nersc"):
+# HPC route
+def hpc_route():
+    print("Setting GUI HPC route...")
+    with RouterViewLayout(server, "/hpc"):
         with vuetify.VRow():
             with vuetify.VCol(cols=4):
-                # Superfacility API card
+                # NERSC Superfacility API card
                 with vuetify.VRow():
                     with vuetify.VCol():
                         load_sfapi_card()
@@ -506,11 +506,11 @@ def gui_setup():
                     prepend_icon="mdi-chat",
                     title="AI Assistant",
                 )
-                # NERSC route
+                # HPC route
                 vuetify.VListItem(
-                    to="/nersc",
+                    to="/hpc",
                     prepend_icon="mdi-lan-connect",
-                    title="NERSC API key",
+                    title="HPC Connection",
                 )
         # interactive dialog for simulation plots
         with vuetify.VDialog(

--- a/dashboard/sfapi_manager.py
+++ b/dashboard/sfapi_manager.py
@@ -110,7 +110,7 @@ def load_sfapi_credentials(**kwargs):
 def load_sfapi_card():
     print("Setting Superfacility API card...")
     with vuetify.VCard():
-        with vuetify.VCardTitle("Superfacility API"):
+        with vuetify.VCardTitle("NERSC Superfacility API"):
             with vuetify.VCardText():
                 # row with component to upload input file
                 with vuetify.VRow():


### PR DESCRIPTION
## Overview

Minor changes extracted from #439. 

## Details

Name changes to prepare upcoming AmSC IRI API additions:
- Renamed the "NERSC API key" route as "HPC Connection".
- Renamed the "Superfacility API" card as "NERSC Superfacility API".
- Renamed variables `nersc_route` as `hpc_route`, `reset_gui_route_nersc` as `reset_gui_route_hpc`, etc.