### PR TITLE
Rename Perlmutter variables specific to Superfacility API

### DIFF
--- a/dashboard/model_manager.py
+++ b/dashboard/model_manager.py
@@ -589,7 +589,7 @@ class ModelManager:
                                 disabled=(
                                     "model_training || "
                                     "(model_training_mode === 'sfapi' && "
-                                    "perlmutter_status !== 'active')",
+                                    "sfapi_perlmutter_status !== 'active')",
                                 ),
                                 block=True,
                                 style="text-transform: none",

--- a/dashboard/parameters_manager.py
+++ b/dashboard/parameters_manager.py
@@ -249,7 +249,7 @@ class ParametersManager:
                                     "Simulate",
                                     click=self.simulation_trigger,
                                     disabled=(
-                                        "simulation_running || perlmutter_status != 'active' || !simulatable",
+                                        "simulation_running || sfapi_perlmutter_status != 'active' || !simulatable",
                                     ),
                                     block=True,
                                     style="text-transform: none",

--- a/dashboard/sfapi_manager.py
+++ b/dashboard/sfapi_manager.py
@@ -62,10 +62,10 @@ def update_sfapi_info():
                 )
                 # update Perlmutter status
                 status = client.compute(Machine.perlmutter)
-                state.perlmutter_description = f"{status.description}"
-                state.perlmutter_status = f"{status.status.value}"
+                state.sfapi_perlmutter_description = f"{status.description}"
+                state.sfapi_perlmutter_status = f"{status.status.value}"
                 print(
-                    f"Perlmutter status is {state.perlmutter_status} with description '{state.perlmutter_description}'"
+                    f"Perlmutter status is {state.sfapi_perlmutter_status} with description '{state.sfapi_perlmutter_description}'"
                 )
             else:
                 # reset key expiration date
@@ -73,8 +73,8 @@ def update_sfapi_info():
                     f"Expired On {expiration.strftime(user_format)}"
                 )
                 # reset Perlmutter status
-                state.perlmutter_description = "Unavailable"
-                state.perlmutter_status = "unavailable"
+                state.sfapi_perlmutter_description = "Unavailable"
+                state.sfapi_perlmutter_status = "unavailable"
                 title = "Unable to find a valid Superfacility API key"
                 msg = f"Superfacility API key expired on {expiration.strftime(user_format)}"
                 add_error(title, msg)
@@ -84,8 +84,8 @@ def update_sfapi_info():
         # reset key expiration date
         state.sfapi_key_expiration = "Unavailable"
         # reset Perlmutter status
-        state.perlmutter_description = "Unavailable"
-        state.perlmutter_status = "unavailable"
+        state.sfapi_perlmutter_description = "Unavailable"
+        state.sfapi_perlmutter_status = "unavailable"
         title = "Unable to connect to NERSC"
         msg = f"Error occurred when connecting to NERSC through the Superfacility API: {e}"
         add_error(title, msg)
@@ -138,7 +138,7 @@ def load_sfapi_card():
                 with vuetify.VRow():
                     with vuetify.VCol():
                         vuetify.VTextField(
-                            v_model=("perlmutter_description",),
+                            v_model=("sfapi_perlmutter_description",),
                             label="Perlmutter Status",
                             readonly=True,
                             hide_details=True,

--- a/dashboard/state_manager.py
+++ b/dashboard/state_manager.py
@@ -47,8 +47,8 @@ def initialize_state():
     state.sfapi_key = None
     state.sfapi_key_dict = None
     state.sfapi_key_expiration = "Unavailable"
-    state.perlmutter_description = "Unavailable"
-    state.perlmutter_status = "unavailable"
+    state.sfapi_perlmutter_description = "Unavailable"
+    state.sfapi_perlmutter_status = "unavailable"
     # Simulation plots in interactive dialog
     state.simulation_url = None
     state.simulation_dialog = False


### PR DESCRIPTION
## Overview

Minor change extracted from #439.

## Details

With #439 we will need to track the status of Perlmutter independently through different APIs (e.g., Superfacility API or IRI API), because different workflows (e.g., ML training or simulations) will be allowed to use different APIs. So the current variable names need to be made more specific.