### PR TITLE
Add globus-sdk to dashboard environment for Globus authentication

### DIFF
--- a/dashboard/environment-lock.yml
+++ b/dashboard/environment-lock.yml
@@ -13,10 +13,10 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 0759f6c24d976444ac929179d4adb90feb470b18cabf61eb73088b653f44fb1d
-    osx-arm64: 19497e8f7bc0e39c269331e3d968cd90ce0ebee4a2e78b3bd85743e22a02b977
-    osx-64: f1b218ffe212849239230cbe132cd1affbe1996bc7f33013d3ff1181f394f713
-    win-64: 1bf154b3ae3660663b43861cda4eefbaa2b49c856f7ea2e1047a6067616451db
+    linux-64: 3d121204e20333ecc0c12d6e74bbabbf75dccd7976565296728eebdb436c16f1
+    osx-arm64: 285b28421f62dfa90f7450575989f90ea4fc4a5ab3cf0447d19efd38d3566682
+    osx-64: 0a72e7b7e571da6aecb6256f1d5aa9bbafc2ca0edeac783180b43b535e1b2ded
+    win-64: 7dfae808ddcd28b342ca7552df2c2cea5e8c5c7a02eb6ae2a962445f6c64a55c
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -439,7 +439,7 @@ package:
   category: main
   optional: false
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -447,14 +447,14 @@ package:
     idna: '>=2.8'
     python: ''
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -462,14 +462,14 @@ package:
     idna: '>=2.8'
     python: '>=3.10'
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -477,14 +477,14 @@ package:
     idna: '>=2.8'
     python: '>=3.10'
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: anyio
-  version: 4.14.0
+  version: 4.14.1
   manager: conda
   platform: win-64
   dependencies:
@@ -492,10 +492,10 @@ package:
     idna: '>=2.8'
     python: '>=3.10'
     typing_extensions: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
   hash:
-    md5: e679dcf15f30bf6e3f1bb3ba69bcf29c
-    sha256: dc9c18c3766f82d88dbe6b25d25580e14fcc94d3c84524f610b713c2a72dd038
+    md5: 7498bb2648f852c6a3cd5724ca80bdeb
+    sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
   category: main
   optional: false
 - name: attrs
@@ -556,12 +556,12 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
   hash:
-    md5: c463d2dbfb12a208c943165d2a568db4
-    sha256: 5b9c20a38fe084b4ffd1f2c64b3797ec6ef9a99e83cc0c1f84e016c9801e3a5c
+    md5: 9329dcd00c4d61aa49e516dddd784e91
+    sha256: 34238103e9b75a9ed0d8b01132551c2af4f9ae68ee2f81320a685ffb27731f6c
   category: main
   optional: false
 - name: aws-c-auth
@@ -574,11 +574,11 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.10.3-h2dfa1e0_2.conda
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.10.3-h0ebf9bf_3.conda
   hash:
-    md5: 512f46909e6c405c20728918f60851b8
-    sha256: 25f88f6ab63db63ef3011084cee06c62bfadde169a630a16588b21d6969320a2
+    md5: 5dcb2e3f244926bf09847f798ff1206a
+    sha256: ec12a2ad9d2979b20722ca387d8a782a925a135599de5a07cc0954f92f088718
   category: main
   optional: false
 - name: aws-c-auth
@@ -591,11 +591,11 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
   hash:
-    md5: e7501df14d3145fc86943ebfeb76a402
-    sha256: b4689664156e8067ba1aa97125f2a309a96b2bc0d1c608f4a88f30ea1f4c9aba
+    md5: 1fc365a60432d78b729d1468fce1b6c9
+    sha256: 623c4f69ce1e2eac92c209ef0e16e5f9ab8832232a749e3a272e11f1f46191c6
   category: main
   optional: false
 - name: aws-c-auth
@@ -607,14 +607,14 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.10.3-h75b6777_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.10.3-h4ad2c79_3.conda
   hash:
-    md5: f19119948955d3f12c96e1922f92159b
-    sha256: 24a2fed6fd65e5af176025bbe1af91baf43d0beb037ee8513ae47f3221a8f89e
+    md5: 6aedfd77c6667e5b107c7907002e98a4
+    sha256: 590ab6432edcbd9cab6e48bb10f22f42c4a5d17592c3d8b88beebe53249c42ce
   category: main
   optional: false
 - name: aws-c-cal
@@ -973,7 +973,7 @@ package:
   category: main
   optional: false
 - name: aws-c-mqtt
-  version: 0.15.2
+  version: 0.16.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -982,14 +982,14 @@ package:
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.15.2-h0d2f46f_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.16.0-h0d2f46f_0.conda
   hash:
-    md5: c66a882d62800e451a651b9b002f5066
-    sha256: c81aa872f74baf6bd2bb82cc87815895b3a654ef7831177a5c3d851ee27c05ea
+    md5: 94454ba09f610904865601eae5530600
+    sha256: 2a9ae1da09ae77d0d513ebaaa0e3810f33e4e09b564494c62d50d7d9f217334e
   category: main
   optional: false
 - name: aws-c-mqtt
-  version: 0.15.2
+  version: 0.16.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -997,14 +997,14 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.15.2-h60a7cf6_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.16.0-h60a7cf6_0.conda
   hash:
-    md5: bfdfb69208c68204ebe3fefa640efb32
-    sha256: 6d035740e2a61a8bdec8405c68d78e5ac7e23582071bb6fc82d83f34191db5b6
+    md5: 77e280c0efc9dcc063e2979e8c2a7371
+    sha256: c4b02491a15e7ca6e92856c2f3712f6726bf412e11938228c8c375b272129730
   category: main
   optional: false
 - name: aws-c-mqtt
-  version: 0.15.2
+  version: 0.16.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1012,14 +1012,14 @@ package:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.15.2-ha70999f_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
   hash:
-    md5: 24f47ec268da87f530058df459de3dad
-    sha256: ab15db26173d775b92503808bd4c29bfca484d5feb6b639793f8adba3004c56e
+    md5: 23ef6506ce17c3ed79db869898f99598
+    sha256: 311a2051eb2e48664229a9b10886013c4c059aef602b70909ac1bc8d2000fc6d
   category: main
   optional: false
 - name: aws-c-mqtt
-  version: 0.15.2
+  version: 0.16.0
   manager: conda
   platform: win-64
   dependencies:
@@ -1029,14 +1029,14 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.15.2-h10b66d2_4.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.16.0-h10b66d2_0.conda
   hash:
-    md5: 59085b30e82152df2c9fa58e358ac9db
-    sha256: a2bd3f799866fe82c29e1b0a16f7c8c19f76cb67e26caaf454d23695f5f5e007
+    md5: 2ce70960360c7672e456e8dd963f5bee
+    sha256: c77d3431ac4e4d3512ebc10e3ae82370f82183ec2c771f7f763392f5c1c471fc
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -1048,15 +1048,15 @@ package:
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
   hash:
-    md5: 70bc8e5e8cefd19407423733e7ebf540
-    sha256: 8f193173f1dccb25ff86a95543db27f0c762cccfe93157b02cf20bd5b4c11a92
+    md5: f2b6275244daa12109bcd0a126f1fb85
+    sha256: bda2c735382e2232997fb34c5d71d476ab2f4e5ba5bc9e059106f280f2334a88
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: osx-64
   dependencies:
@@ -1067,14 +1067,14 @@ package:
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.12.5-h8cc6e82_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.12.6-h8cc6e82_0.conda
   hash:
-    md5: 75914204f2c708212f2185abeca539b4
-    sha256: 2077da563f7e81f007a4eac4b233931c8500b3ca3aae50ef37001fa90e133792
+    md5: 9cdf6d338f7553cd715b2569b8d34ce6
+    sha256: d692471963cebb98a895bda88934c8b629b3c9eb2a39290a74ffbf5769a15f7c
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1085,14 +1085,14 @@ package:
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
   hash:
-    md5: 7dc63973f9fe772985b8c2f8ba5958ce
-    sha256: 0a99b506bbe21f00f21047db50b2eea2ff8a0b1146ff0fba7d04b39a568453f4
+    md5: 912c61c44a2782693d63af2272551455
+    sha256: 258678f29912d503e4301814f411b29bb2324f6a0131a06a385f2280b4916eeb
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.12.5
+  version: 0.12.6
   manager: conda
   platform: win-64
   dependencies:
@@ -1105,54 +1105,54 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.12.5-h425879c_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.12.6-h425879c_0.conda
   hash:
-    md5: 0329818a49b00c486916f6d7d5b65a71
-    sha256: bde30210fe7d355227bf303a582ff11e340ac685156139cd7a9ef08dfe6c037f
+    md5: d48ab0822e0cd063f28f9bdc3b131025
+    sha256: 79480a3e2cdc9996bcf956c40da69af7f0c381025d3a3767bca3bfd9ab7ad5a7
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
   hash:
-    md5: 4b66ac29a7e917a629b790c3d239d110
-    sha256: 123c4325b16f1f6db95846d51e5e4201399ee29c0325f8b5a8db2e7d732b9151
+    md5: 5088795f3dfcf00a26f03c2a17ae8429
+    sha256: c351a2bb8734accc6a047b55be15a8ce205725aeeedd2576c320841c3c383731
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.4-ha04291d_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.5-ha04291d_0.conda
   hash:
-    md5: 2d3f039770cab013521cc78e84b34e64
-    sha256: 44bca0a25e978729b995f2f265e0576d32292a4cc23953beafa233fec8f6184e
+    md5: a419d964954a7885cd5c10bc79d5ccf5
+    sha256: bfa4583104c63c3a0ffb5b68bc78aff0f75089bce2e5f68933599de4be543e61
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
   hash:
-    md5: 127bce41f9e6cc3bdb9e6daed95896d9
-    sha256: ef53cd1e30bc8c865c44df6f097f36361945665157e63957d68fe90aa7e4d66c
+    md5: 4a91f77674daaa9e0a6bbcf9a45d23fd
+    sha256: f47cd32244c77d12bfbf9ae1eecf6672d776f9df8f5357c365fd8254e3d2acb9
   category: main
   optional: false
 - name: aws-c-sdkutils
-  version: 0.2.4
+  version: 0.2.5
   manager: conda
   platform: win-64
   dependencies:
@@ -1160,10 +1160,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.4-h1f21522_6.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.5-h1f21522_0.conda
   hash:
-    md5: c1380960068cc10d06ddcab8cb97f439
-    sha256: bd47b93b91ecb7d7ff82be44bb70e109f7cbb7c512c4579772652c46cbdf6597
+    md5: a9f7e722616c9d49c1bfd50907f96af4
+    sha256: d81e792b5196631fb94bebe889dbb553934c82395c83da434fe20c0931b279a0
   category: main
   optional: false
 - name: aws-checksums
@@ -1222,7 +1222,7 @@ package:
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.40.0
+  version: 0.40.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -1233,19 +1233,19 @@ package:
     aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.15.2,<0.15.3.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.40.0-h41299d8_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.40.1-h7a9a9d6_1.conda
   hash:
-    md5: b4fbfcaea33878c12f0e035f5814280b
-    sha256: cc8eade570327e97ea458dd47dad9845fce5be070024a3fdaffe5aa4f68d2126
+    md5: 976bc22e043e8380f3dd54863b73ecef
+    sha256: 55d39d93aaa69ac47831db4c0661b8112e719d74950fecd4bcbf9181ea6f7d34
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.40.0
+  version: 0.40.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -1256,18 +1256,18 @@ package:
     aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.15.2,<0.15.3.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.40.0-h29c3229_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.40.1-h2224057_1.conda
   hash:
-    md5: 5f3b48a9b1420e24f156f2aab77cb6fa
-    sha256: 9592201c5e533e031542fc06c546afb1535b7731a11828d7fd24a8df2717ffa4
+    md5: a6de3b44007e45268ea5728ea9fb0573
+    sha256: 37c0925b8e5bd904d51ef12c856934617dcf772c27e6a495891731e4a1e1782c
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.40.0
+  version: 0.40.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1278,18 +1278,18 @@ package:
     aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.15.2,<0.15.3.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.40.0-hd6eb0f7_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
   hash:
-    md5: 522e7961ac3402ab3814d9759f7c54de
-    sha256: 258cea4855f3d289dce09ab197bf2abfb5e983fefce371e4d100ec1a8d015277
+    md5: 602dd44df5dd28061de3ee798e991b42
+    sha256: 6d2b0bf67403c53f6954b7602e529cac91b1d156b22f71db5d97bf9ebc269790
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.40.0
+  version: 0.40.1
   manager: conda
   platform: win-64
   dependencies:
@@ -1299,89 +1299,89 @@ package:
     aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
     aws-c-http: '>=0.11.0,<0.11.1.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-mqtt: '>=0.15.2,<0.15.3.0a0'
-    aws-c-s3: '>=0.12.5,<0.12.6.0a0'
-    aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
+    aws-c-mqtt: '>=0.16.0,<0.16.1.0a0'
+    aws-c-s3: '>=0.12.6,<0.12.7.0a0'
+    aws-c-sdkutils: '>=0.2.5,<0.2.6.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.40.0-hcaec180_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.40.1-hccacdf3_1.conda
   hash:
-    md5: efcf4340a1d932d462cc333d1be7862d
-    sha256: 524e7fcb31c88150f51e4f2750a8e0a083a374abcad29c9cf1b064f5a7971b2e
+    md5: 10925fdb0adcf0d06a920a0a188459c3
+    sha256: 6f719b087dc3d7d9782c415b7881d8f4e8a93db33fa0e80b300f1527156c2ec7
   category: main
   optional: false
 - name: aws-sdk-cpp
-  version: 1.11.747
+  version: 1.11.833
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.0,<0.40.1.0a0'
+    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h6154047_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.833-hf4c7647_7.conda
   hash:
-    md5: 9096d36ad4522d330bd6a5bdbd458275
-    sha256: 224c461787555e92a1111b8a5c7f65db0559da631f05b0e29d06e79a267cc130
+    md5: 12ae84178a356ce6b073b0273942708b
+    sha256: 36587b55dfdf42b8dd8c3ab3c09c6ca87f110fc312facba1f26c73fb39cc63e0
   category: main
   optional: false
 - name: aws-sdk-cpp
-  version: 1.11.747
+  version: 1.11.833
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.0,<0.40.1.0a0'
+    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libcxx: '>=19'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.747-h6b5c32a_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.833-h18965b5_7.conda
   hash:
-    md5: 472743e866a6dbff31a9b784be804501
-    sha256: 6e94795256fded99749f3e76ed98c5e5b289d2d64ef53b5ac0c3e424c97c261c
+    md5: 871fe827d098707a31af910f656d2d80
+    sha256: 4a6e21b8f6b39d2d500e42d258a9721fd243d80ca79ebab6eff5596f9abf291f
   category: main
   optional: false
 - name: aws-sdk-cpp
-  version: 1.11.747
+  version: 1.11.833
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.0,<0.40.1.0a0'
+    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
     libcxx: '>=19'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h55dad5a_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.833-h4e95165_7.conda
   hash:
-    md5: 391aa9618724ce3a08901de5ae43c447
-    sha256: 9fa8fcc0da0b26269e488f8db252d416062671b55fbb57bc81c049343567ac37
+    md5: 471a7d617fb3e2da7d8e036dec8d47ae
+    sha256: b15f6ce46e33e37dae8847f5125814a595e69ffab21f9b8b115077e72f6ccebf
   category: main
   optional: false
 - name: aws-sdk-cpp
-  version: 1.11.747
+  version: 1.11.833
   manager: conda
   platform: win-64
   dependencies:
     aws-c-common: '>=0.14.0,<0.14.1.0a0'
     aws-c-event-stream: '>=0.7.1,<0.7.2.0a0'
-    aws-crt-cpp: '>=0.40.0,<0.40.1.0a0'
+    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.747-h5d5b8b4_6.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.833-h042817b_7.conda
   hash:
-    md5: 3b7f809b73ed77b3394f2c5ea743db8b
-    sha256: 3401c3f8a9968319ba1a697bd5f23b51d01958995c91c8c8bcda03ded0039dff
+    md5: b147435fc3724fde9fac3911dfb04d53
+    sha256: 103f416e19d499cc9c5b9775eeeb470cdb1713140b496f41d26c5f5889f9f01c
   category: main
   optional: false
 - name: azure-core-cpp
@@ -3070,7 +3070,7 @@ package:
   category: main
   optional: false
 - name: databricks-sdk
-  version: 0.117.0
+  version: 0.119.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -3078,14 +3078,14 @@ package:
     protobuf: '>=4.25.8,!=5.26.*,!=5.27.*,!=5.28.*,!=5.29.0,!=5.29.1,!=5.29.2,!=5.29.3,!=5.29.4,!=6.30.0,!=6.30.1,!=6.31.0,<7.0'
     python: '>=3.10'
     requests: '>=2.28.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.117.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.119.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc536ee65573cc1788fd0377e535a30
-    sha256: adb849f7c3f71f988bd5c32b3fd0ef23d8e593e845d21622fc54eb1416e191ba
+    md5: ab270abfa8018995f32ae74f0b1999ca
+    sha256: 1c6c75d31e5631a86cce7184a6cceb9b4c18948722ced544e84a9e4707b9c528
   category: main
   optional: false
 - name: databricks-sdk
-  version: 0.117.0
+  version: 0.119.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -3093,14 +3093,14 @@ package:
     protobuf: '>=4.25.8,!=5.26.*,!=5.27.*,!=5.28.*,!=5.29.0,!=5.29.1,!=5.29.2,!=5.29.3,!=5.29.4,!=6.30.0,!=6.30.1,!=6.31.0,<7.0'
     python: '>=3.10'
     requests: '>=2.28.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.117.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.119.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc536ee65573cc1788fd0377e535a30
-    sha256: adb849f7c3f71f988bd5c32b3fd0ef23d8e593e845d21622fc54eb1416e191ba
+    md5: ab270abfa8018995f32ae74f0b1999ca
+    sha256: 1c6c75d31e5631a86cce7184a6cceb9b4c18948722ced544e84a9e4707b9c528
   category: main
   optional: false
 - name: databricks-sdk
-  version: 0.117.0
+  version: 0.119.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3108,14 +3108,14 @@ package:
     protobuf: '>=4.25.8,!=5.26.*,!=5.27.*,!=5.28.*,!=5.29.0,!=5.29.1,!=5.29.2,!=5.29.3,!=5.29.4,!=6.30.0,!=6.30.1,!=6.31.0,<7.0'
     python: '>=3.10'
     requests: '>=2.28.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.117.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.119.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc536ee65573cc1788fd0377e535a30
-    sha256: adb849f7c3f71f988bd5c32b3fd0ef23d8e593e845d21622fc54eb1416e191ba
+    md5: ab270abfa8018995f32ae74f0b1999ca
+    sha256: 1c6c75d31e5631a86cce7184a6cceb9b4c18948722ced544e84a9e4707b9c528
   category: main
   optional: false
 - name: databricks-sdk
-  version: 0.117.0
+  version: 0.119.0
   manager: conda
   platform: win-64
   dependencies:
@@ -3123,10 +3123,10 @@ package:
     protobuf: '>=4.25.8,!=5.26.*,!=5.27.*,!=5.28.*,!=5.29.0,!=5.29.1,!=5.29.2,!=5.29.3,!=5.29.4,!=6.30.0,!=6.30.1,!=6.31.0,<7.0'
     python: '>=3.10'
     requests: '>=2.28.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.117.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.119.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3bc536ee65573cc1788fd0377e535a30
-    sha256: adb849f7c3f71f988bd5c32b3fd0ef23d8e593e845d21622fc54eb1416e191ba
+    md5: ab270abfa8018995f32ae74f0b1999ca
+    sha256: 1c6c75d31e5631a86cce7184a6cceb9b4c18948722ced544e84a9e4707b9c528
   category: main
   optional: false
 - name: deprecated
@@ -3506,13 +3506,13 @@ package:
   category: main
   optional: false
 - name: fastapi
-  version: 0.137.2
+  version: 0.138.1
   manager: conda
   platform: linux-64
   dependencies:
     email_validator: ''
     fastapi-cli: ''
-    fastapi-core: ==0.137.2
+    fastapi-core: ==0.138.1
     fastar: ''
     httpx: ''
     jinja2: ''
@@ -3520,20 +3520,20 @@ package:
     pydantic-settings: ''
     python-multipart: ''
     uvicorn-standard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.137.2-hb8814d4_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.138.1-h3ca0737_0.conda
   hash:
-    md5: 1a4df021798c91bd29b60d351b4c5831
-    sha256: 04bddf8c5127f2bad4c84a4aa894a000a5b0b2d5c31eaf55fd0a2142dcc0f10c
+    md5: 29b857c2bf6269dd7b9b039ed77bf7f5
+    sha256: f9ae3064a8c36075e4ccc2d629c9c1772062580d1ded493d3c964a7b62e5f1d6
   category: main
   optional: false
 - name: fastapi
-  version: 0.137.2
+  version: 0.138.1
   manager: conda
   platform: osx-64
   dependencies:
     email_validator: ''
     fastapi-cli: ''
-    fastapi-core: ==0.137.2
+    fastapi-core: ==0.138.1
     fastar: ''
     httpx: ''
     jinja2: ''
@@ -3541,20 +3541,20 @@ package:
     pydantic-settings: ''
     python-multipart: ''
     uvicorn-standard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.137.2-hb8814d4_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.138.1-h3ca0737_0.conda
   hash:
-    md5: 1a4df021798c91bd29b60d351b4c5831
-    sha256: 04bddf8c5127f2bad4c84a4aa894a000a5b0b2d5c31eaf55fd0a2142dcc0f10c
+    md5: 29b857c2bf6269dd7b9b039ed77bf7f5
+    sha256: f9ae3064a8c36075e4ccc2d629c9c1772062580d1ded493d3c964a7b62e5f1d6
   category: main
   optional: false
 - name: fastapi
-  version: 0.137.2
+  version: 0.138.1
   manager: conda
   platform: osx-arm64
   dependencies:
     email_validator: ''
     fastapi-cli: ''
-    fastapi-core: ==0.137.2
+    fastapi-core: ==0.138.1
     fastar: ''
     httpx: ''
     jinja2: ''
@@ -3562,20 +3562,20 @@ package:
     pydantic-settings: ''
     python-multipart: ''
     uvicorn-standard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.137.2-hb8814d4_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.138.1-h3ca0737_0.conda
   hash:
-    md5: 1a4df021798c91bd29b60d351b4c5831
-    sha256: 04bddf8c5127f2bad4c84a4aa894a000a5b0b2d5c31eaf55fd0a2142dcc0f10c
+    md5: 29b857c2bf6269dd7b9b039ed77bf7f5
+    sha256: f9ae3064a8c36075e4ccc2d629c9c1772062580d1ded493d3c964a7b62e5f1d6
   category: main
   optional: false
 - name: fastapi
-  version: 0.137.2
+  version: 0.138.1
   manager: conda
   platform: win-64
   dependencies:
     email_validator: ''
     fastapi-cli: ''
-    fastapi-core: ==0.137.2
+    fastapi-core: ==0.138.1
     fastar: ''
     httpx: ''
     jinja2: ''
@@ -3583,14 +3583,14 @@ package:
     pydantic-settings: ''
     python-multipart: ''
     uvicorn-standard: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.137.2-hb8814d4_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.138.1-h3ca0737_0.conda
   hash:
-    md5: 1a4df021798c91bd29b60d351b4c5831
-    sha256: 04bddf8c5127f2bad4c84a4aa894a000a5b0b2d5c31eaf55fd0a2142dcc0f10c
+    md5: 29b857c2bf6269dd7b9b039ed77bf7f5
+    sha256: f9ae3064a8c36075e4ccc2d629c9c1772062580d1ded493d3c964a7b62e5f1d6
   category: main
   optional: false
 - name: fastapi-cli
-  version: 0.0.26
+  version: 0.0.27
   manager: conda
   platform: linux-64
   dependencies:
@@ -3599,14 +3599,14 @@ package:
     tomli: '>=2.0.0'
     typer: '>=0.16'
     uvicorn-standard: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.26-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.27-pyhcf101f3_0.conda
   hash:
-    md5: ce89eed1ab952a6467b184911857ce31
-    sha256: 005858be2cccd46063708bcce85dbb438c691f000de65279d560ef4e8bea0bbf
+    md5: be7cfefffd8f38de299a0473621f03f7
+    sha256: da42816d85b9775ba03e47f5d395998655f61bbce4770a203024ffaf601ede09
   category: main
   optional: false
 - name: fastapi-cli
-  version: 0.0.26
+  version: 0.0.27
   manager: conda
   platform: osx-64
   dependencies:
@@ -3615,14 +3615,14 @@ package:
     tomli: '>=2.0.0'
     typer: '>=0.16'
     uvicorn-standard: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.26-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.27-pyhcf101f3_0.conda
   hash:
-    md5: ce89eed1ab952a6467b184911857ce31
-    sha256: 005858be2cccd46063708bcce85dbb438c691f000de65279d560ef4e8bea0bbf
+    md5: be7cfefffd8f38de299a0473621f03f7
+    sha256: da42816d85b9775ba03e47f5d395998655f61bbce4770a203024ffaf601ede09
   category: main
   optional: false
 - name: fastapi-cli
-  version: 0.0.26
+  version: 0.0.27
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3631,14 +3631,14 @@ package:
     tomli: '>=2.0.0'
     typer: '>=0.16'
     uvicorn-standard: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.26-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.27-pyhcf101f3_0.conda
   hash:
-    md5: ce89eed1ab952a6467b184911857ce31
-    sha256: 005858be2cccd46063708bcce85dbb438c691f000de65279d560ef4e8bea0bbf
+    md5: be7cfefffd8f38de299a0473621f03f7
+    sha256: da42816d85b9775ba03e47f5d395998655f61bbce4770a203024ffaf601ede09
   category: main
   optional: false
 - name: fastapi-cli
-  version: 0.0.26
+  version: 0.0.27
   manager: conda
   platform: win-64
   dependencies:
@@ -3647,14 +3647,14 @@ package:
     tomli: '>=2.0.0'
     typer: '>=0.16'
     uvicorn-standard: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.26-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.27-pyhcf101f3_0.conda
   hash:
-    md5: ce89eed1ab952a6467b184911857ce31
-    sha256: 005858be2cccd46063708bcce85dbb438c691f000de65279d560ef4e8bea0bbf
+    md5: be7cfefffd8f38de299a0473621f03f7
+    sha256: da42816d85b9775ba03e47f5d395998655f61bbce4770a203024ffaf601ede09
   category: main
   optional: false
 - name: fastapi-core
-  version: 0.137.2
+  version: 0.138.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -3664,14 +3664,14 @@ package:
     starlette: '>=0.46.0'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.137.2-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.138.1-pyhcf101f3_0.conda
   hash:
-    md5: d5e4f06a67fb9ed554ab1543f33d1347
-    sha256: 3f34cda6ae2bc45659b924cd8fd3eef8c16225cb714302544f54c491bd4f97ef
+    md5: 182e465661f3b14d953f640478312b2f
+    sha256: 3bdf08929cd6d02444a08513d184614e028ba0a50f71cb3dd60f90245a9ddcdb
   category: main
   optional: false
 - name: fastapi-core
-  version: 0.137.2
+  version: 0.138.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -3681,14 +3681,14 @@ package:
     starlette: '>=0.46.0'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.137.2-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.138.1-pyhcf101f3_0.conda
   hash:
-    md5: d5e4f06a67fb9ed554ab1543f33d1347
-    sha256: 3f34cda6ae2bc45659b924cd8fd3eef8c16225cb714302544f54c491bd4f97ef
+    md5: 182e465661f3b14d953f640478312b2f
+    sha256: 3bdf08929cd6d02444a08513d184614e028ba0a50f71cb3dd60f90245a9ddcdb
   category: main
   optional: false
 - name: fastapi-core
-  version: 0.137.2
+  version: 0.138.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3698,14 +3698,14 @@ package:
     starlette: '>=0.46.0'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.137.2-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.138.1-pyhcf101f3_0.conda
   hash:
-    md5: d5e4f06a67fb9ed554ab1543f33d1347
-    sha256: 3f34cda6ae2bc45659b924cd8fd3eef8c16225cb714302544f54c491bd4f97ef
+    md5: 182e465661f3b14d953f640478312b2f
+    sha256: 3bdf08929cd6d02444a08513d184614e028ba0a50f71cb3dd60f90245a9ddcdb
   category: main
   optional: false
 - name: fastapi-core
-  version: 0.137.2
+  version: 0.138.1
   manager: conda
   platform: win-64
   dependencies:
@@ -3715,10 +3715,10 @@ package:
     starlette: '>=0.46.0'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.137.2-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.138.1-pyhcf101f3_0.conda
   hash:
-    md5: d5e4f06a67fb9ed554ab1543f33d1347
-    sha256: 3f34cda6ae2bc45659b924cd8fd3eef8c16225cb714302544f54c491bd4f97ef
+    md5: 182e465661f3b14d953f640478312b2f
+    sha256: 3bdf08929cd6d02444a08513d184614e028ba0a50f71cb3dd60f90245a9ddcdb
   category: main
   optional: false
 - name: fastar
@@ -5639,51 +5639,51 @@ package:
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: hpack
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a802cb9888dd14eeefc611f05c40b6e
-    sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+    md5: b395909221b9bd1df066e5930e18855b
+    sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
   category: main
   optional: false
 - name: httpcore
@@ -6364,55 +6364,55 @@ package:
   category: main
   optional: false
 - name: jaxtyping
-  version: 0.3.7
+  version: 0.3.11
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.11'
     wadler-lindig: '>=0.1.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.11-pyhd8ed1ab_0.conda
   hash:
-    md5: 96387643c6c475b099766f98c41242f0
-    sha256: f6d39c7a9acf6289e75444c032a7154bba5abb45b16feb4013e12250cd485cc2
+    md5: d2fa6995ffc3e55ea22e70c6582489ab
+    sha256: e0c861f192c9640ffdc74c6c813012d1cce48038e456a16fcf464b99b77feae1
   category: main
   optional: false
 - name: jaxtyping
-  version: 0.3.7
+  version: 0.3.11
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.11'
     wadler-lindig: '>=0.1.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.11-pyhd8ed1ab_0.conda
   hash:
-    md5: 96387643c6c475b099766f98c41242f0
-    sha256: f6d39c7a9acf6289e75444c032a7154bba5abb45b16feb4013e12250cd485cc2
+    md5: d2fa6995ffc3e55ea22e70c6582489ab
+    sha256: e0c861f192c9640ffdc74c6c813012d1cce48038e456a16fcf464b99b77feae1
   category: main
   optional: false
 - name: jaxtyping
-  version: 0.3.7
+  version: 0.3.11
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.11'
     wadler-lindig: '>=0.1.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.11-pyhd8ed1ab_0.conda
   hash:
-    md5: 96387643c6c475b099766f98c41242f0
-    sha256: f6d39c7a9acf6289e75444c032a7154bba5abb45b16feb4013e12250cd485cc2
+    md5: d2fa6995ffc3e55ea22e70c6582489ab
+    sha256: e0c861f192c9640ffdc74c6c813012d1cce48038e456a16fcf464b99b77feae1
   category: main
   optional: false
 - name: jaxtyping
-  version: 0.3.7
+  version: 0.3.11
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.10'
+    python: '>=3.11'
     wadler-lindig: '>=0.1.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.11-pyhd8ed1ab_0.conda
   hash:
-    md5: 96387643c6c475b099766f98c41242f0
-    sha256: f6d39c7a9acf6289e75444c032a7154bba5abb45b16feb4013e12250cd485cc2
+    md5: d2fa6995ffc3e55ea22e70c6582489ab
+    sha256: e0c861f192c9640ffdc74c6c813012d1cce48038e456a16fcf464b99b77feae1
   category: main
   optional: false
 - name: jinja2
@@ -6604,11 +6604,11 @@ package:
     libedit: '>=3.1.20250104,<4.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
   hash:
-    md5: fb53fb07ce46a575c5d004bbc96032c2
-    sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
+    md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+    sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
   category: main
   optional: false
 - name: krb5
@@ -6616,14 +6616,14 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
     libedit: '>=3.1.20250104,<4.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.22.2-h207b36a_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.22.2-h3ddfcb2_1.conda
   hash:
-    md5: e66e2c52d2fdddcf314ad750fb4ebb4a
-    sha256: df009385e8262c234c0dae9016540b86dad3d299f0d9366d08e327e8e7731634
+    md5: e070b249c4f9c6bddb7984a1a794e8df
+    sha256: c6342c340b18651d14b6134e223904da6f6099665e45449efb683d4c68b28432
   category: main
   optional: false
 - name: krb5
@@ -6634,11 +6634,11 @@ package:
     __osx: '>=11.0'
     libcxx: '>=19'
     libedit: '>=3.1.20250104,<4.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
   hash:
-    md5: e446e1822f4da8e5080a9de93474184d
-    sha256: c0a0bf028fe7f3defcdcaa464e536cf1b202d07451e18ad83fdd169d15bef6ed
+    md5: 8780f41b013d19219faef9c82260744b
+    sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
   category: main
   optional: false
 - name: krb5
@@ -6646,14 +6646,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    openssl: '>=3.5.5,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h719d79b_1.conda
   hash:
-    md5: 4432f52dc0c8eb6a7a6abc00a037d93c
-    sha256: eb60f1ad8b597bcf95dee11bc11fe71a8325bc1204cf51d2bb1f2120ffd77761
+    md5: 00335c2c4a98656554771aaf6f1a7400
+    sha256: c55745796e762ba9e817ab1fc0f21f1a049e202f90fa762df39578f37923f6c2
   category: main
   optional: false
 - name: lcms2
@@ -6842,8 +6842,8 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-crt-cpp: '>=0.40.0,<0.40.1.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
+    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
+    aws-sdk-cpp: '>=1.11.833,<1.11.834.0a0'
     azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
     azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
     azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
@@ -6854,8 +6854,8 @@ package:
     libbrotlidec: '>=1.2.0,<1.3.0a0'
     libbrotlienc: '>=1.2.0,<1.3.0a0'
     libgcc: '>=14'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
+    libgoogle-cloud: '>=3.6.0,<3.7.0a0'
+    libgoogle-cloud-storage: '>=3.6.0,<3.7.0a0'
     libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libstdcxx: '>=14'
@@ -6864,10 +6864,10 @@ package:
     orc: '>=2.3.0,<2.3.1.0a0'
     snappy: '>=1.2.2,<1.3.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-23.0.1-h157cd41_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-23.0.1-h3e48024_16_cpu.conda
   hash:
-    md5: 6c57f3e06829e9372e961e026775edf3
-    sha256: 8aca11b209b56414224cb8c3232d7b37adeb7423c430ea0b4a8bfc8c052d669c
+    md5: fcaa7684073942da37365325c747de25
+    sha256: e15df61a789374eb7179b82bf25a88ce1b140fae0f9a224dc08bbc753a73bd59
   category: main
   optional: false
 - name: libarrow
@@ -6876,8 +6876,8 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-    aws-crt-cpp: '>=0.40.0,<0.40.1.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
+    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
+    aws-sdk-cpp: '>=1.11.833,<1.11.834.0a0'
     azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
     azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
     azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
@@ -6888,8 +6888,8 @@ package:
     libbrotlidec: '>=1.2.0,<1.3.0a0'
     libbrotlienc: '>=1.2.0,<1.3.0a0'
     libcxx: '>=21'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
+    libgoogle-cloud: '>=3.6.0,<3.7.0a0'
+    libgoogle-cloud-storage: '>=3.6.0,<3.7.0a0'
     libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libzlib: '>=1.3.2,<2.0a0'
@@ -6897,10 +6897,10 @@ package:
     orc: '>=2.3.0,<2.3.1.0a0'
     snappy: '>=1.2.2,<1.3.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-23.0.1-h5f9a77d_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-23.0.1-h0b461ca_16_cpu.conda
   hash:
-    md5: a8ee719dd72e1354f9561bde5ebccf7a
-    sha256: 3d004b9f2dc2994f077b71350250167c1257a468ff17818a8c6bb9b2e0bc095f
+    md5: 3335724cb5746ca40be5cd1ca516734a
+    sha256: ba2a3778d4032d69177a2cf39e4e04e9e90b895684c475cc2551c6c4d7bacfd2
   category: main
   optional: false
 - name: libarrow
@@ -6909,8 +6909,8 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-crt-cpp: '>=0.40.0,<0.40.1.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
+    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
+    aws-sdk-cpp: '>=1.11.833,<1.11.834.0a0'
     azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
     azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
     azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
@@ -6921,8 +6921,8 @@ package:
     libbrotlidec: '>=1.2.0,<1.3.0a0'
     libbrotlienc: '>=1.2.0,<1.3.0a0'
     libcxx: '>=21'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
+    libgoogle-cloud: '>=3.6.0,<3.7.0a0'
+    libgoogle-cloud-storage: '>=3.6.0,<3.7.0a0'
     libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libzlib: '>=1.3.2,<2.0a0'
@@ -6930,10 +6930,10 @@ package:
     orc: '>=2.3.0,<2.3.1.0a0'
     snappy: '>=1.2.2,<1.3.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-23.0.1-hc887bfb_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-23.0.1-h30967a1_16_cpu.conda
   hash:
-    md5: 70f5474ecee327f523b115889e74ff44
-    sha256: cae390ac5fb53e69980c1cae76e8de12a6438816a5d7aa754a019d58da65092a
+    md5: 8f69bbb44ab488eff1658245c4f576f4
+    sha256: 7e9d9b71a7186d4ced051f75c245e29a4aff711ca83bb55bb29a610624d8a868
   category: main
   optional: false
 - name: libarrow
@@ -6941,8 +6941,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    aws-crt-cpp: '>=0.40.0,<0.40.1.0a0'
-    aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
+    aws-crt-cpp: '>=0.40.1,<0.40.2.0a0'
+    aws-sdk-cpp: '>=1.11.833,<1.11.834.0a0'
     azure-core-cpp: '>=1.16.3,<1.16.4.0a0'
     azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
     azure-storage-blobs-cpp: '>=12.18.0,<12.18.1.0a0'
@@ -6953,8 +6953,8 @@ package:
     libbrotlienc: '>=1.2.0,<1.3.0a0'
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: '>=8.20.0,<9.0a0'
-    libgoogle-cloud: '>=3.5.0,<3.6.0a0'
-    libgoogle-cloud-storage: '>=3.5.0,<3.6.0a0'
+    libgoogle-cloud: '>=3.6.0,<3.7.0a0'
+    libgoogle-cloud-storage: '>=3.6.0,<3.7.0a0'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
@@ -6964,10 +6964,10 @@ package:
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-23.0.1-hbef6419_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-23.0.1-hcc6a8f1_16_cpu.conda
   hash:
-    md5: d43cbf0dfa0b912824d24586411d66e6
-    sha256: f0b80d5bb9e18de337a8377379b51d1edd1a963ee6f9bde164ff84e9ec056f0b
+    md5: b2b5260624a4055f60c55790c1d6039f
+    sha256: 5a2d218c0abe7e093d4b6dfd3f1212b019cf84beeff77208afee72e5691fff42
   category: main
   optional: false
 - name: libarrow-acero
@@ -6980,10 +6980,10 @@ package:
     libarrow-compute: 23.0.1
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-23.0.1-h635bf11_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-23.0.1-h635bf11_16_cpu.conda
   hash:
-    md5: 8f0ae7c6081e1090c1fc72953e629e11
-    sha256: 65d03b5511250f161b18a856e910fd6c5cb3d6db7b06baa7f799edc1fd1d3b95
+    md5: e9c7b26292ed0b2753755217b6e5b297
+    sha256: f492faa3512f0c7706802779a8086fe1f1b81b6f8eb2858c0d4a38b1f8a5bd78
   category: main
   optional: false
 - name: libarrow-acero
@@ -6998,10 +6998,10 @@ package:
     libcxx: '>=21'
     libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-23.0.1-h91633f5_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-23.0.1-h91633f5_16_cpu.conda
   hash:
-    md5: 29e7a8f224966376d6b68747b2bfcf97
-    sha256: d5c50306861016e493fd8ddd7989036819395001de030109fb12e7efe34d8755
+    md5: 4a69b5042216a4e6546c9ae51f444988
+    sha256: d82954d1c50a43725de51fa3dd330633c54ff90ffe304a9edc6f8ad0fc112702
   category: main
   optional: false
 - name: libarrow-acero
@@ -7016,10 +7016,10 @@ package:
     libcxx: '>=21'
     libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-23.0.1-ha4f4840_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-23.0.1-ha4f4840_16_cpu.conda
   hash:
-    md5: 3acba7ecf0581ddc7752c39fa19d3a02
-    sha256: 29c7c9f0b34c87a72e11d4dda87bf29f6ddc816dd8fa15112cea85e70566e373
+    md5: adad165e6c95f710133a87deaae7f73a
+    sha256: 4bf28c0c8dfe459f092f9bb9ad40980b5d9bdc8b7fedc27f9c843697b6f42540
   category: main
   optional: false
 - name: libarrow-acero
@@ -7032,10 +7032,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-23.0.1-h7d8d6a5_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-23.0.1-h7d8d6a5_16_cpu.conda
   hash:
-    md5: 9593aa89148c4b91ec48f65ef655054a
-    sha256: dd840e843aec50a0c1a0240cf62bb462c563f84236c52eda18c638caaa7745a0
+    md5: e9287a0dcd30c44db0d7f226dafd31b8
+    sha256: 5f1bca31cc059d2d5aa9efcaf66e775e71ac159847376a1e53e1fa8f7c8b6d25
   category: main
   optional: false
 - name: libarrow-compute
@@ -7050,10 +7050,10 @@ package:
     libstdcxx: '>=14'
     libutf8proc: '>=2.11.3,<2.12.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-23.0.1-h53684a4_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-23.0.1-h53684a4_16_cpu.conda
   hash:
-    md5: 4adfff393422526220ffc6650693a1fa
-    sha256: e24c3d520bbaecd39f74cc054bfd3861d3ba98f95f03d313367b2f46a72edc39
+    md5: cf748dd591a0575a062fc9cba99fc550
+    sha256: 16299a1e01587c1dd0871ffdd358abe1395d7dc40d06241b8277c3bbc107d1cd
   category: main
   optional: false
 - name: libarrow-compute
@@ -7070,10 +7070,10 @@ package:
     libre2-11: '>=2025.11.5'
     libutf8proc: '>=2.11.3,<2.12.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-compute-23.0.1-hb38465b_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-compute-23.0.1-hb38465b_16_cpu.conda
   hash:
-    md5: 3cd4f926355408e1c334cd3b6d7aae1c
-    sha256: 8fbcaaec3536192422aa62fd1e160618355579bc96d60f5e3837f84fd74f89e4
+    md5: 4c61f171362009a7c4b9a1ddf45f0b92
+    sha256: ed1a131f64d291fbb8520ef7fa6e5934b08842f9a0677ace0af82b92511a26d0
   category: main
   optional: false
 - name: libarrow-compute
@@ -7090,10 +7090,10 @@ package:
     libre2-11: '>=2025.11.5'
     libutf8proc: '>=2.11.3,<2.12.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-compute-23.0.1-h8d10c55_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-compute-23.0.1-h8d10c55_16_cpu.conda
   hash:
-    md5: 7fa7e2107492f58e2e2df1b6dbbac748
-    sha256: 7407b8ab9dd8b962fbd8ce91657c397482b445106cb7bc1a91c34061a44867c4
+    md5: a9350743e8f8ff6c19f8a995cf70824e
+    sha256: adc8204daa87779215612e5bf4ba2043f9135562a8822ccc2894134512da6adf
   category: main
   optional: false
 - name: libarrow-compute
@@ -7108,10 +7108,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-compute-23.0.1-h081cd8e_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-compute-23.0.1-h081cd8e_16_cpu.conda
   hash:
-    md5: ad7c0d6182a4790783bba1cf3ecb04db
-    sha256: b02c6297c7c1e155e05b6c9d09e9bdd9819f52d6c47dcc28266723750d16cfda
+    md5: 4f75b9b2539ed4263967609061ec69a7
+    sha256: c4527b37d92bab23242bad6c208c9250f77ac07d2d448795bd79df568133c625
   category: main
   optional: false
 - name: libarrow-dataset
@@ -7126,10 +7126,10 @@ package:
     libgcc: '>=14'
     libparquet: 23.0.1
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-23.0.1-h635bf11_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-23.0.1-h635bf11_16_cpu.conda
   hash:
-    md5: 01d057f0cc5de3fc6a7fe02a6dd62574
-    sha256: 1535923bf2ed80485a00308800a10d819610332b1ea048a0b26ffd9d2113d26f
+    md5: e6d57b8510c6dac47df53d39f338e7c1
+    sha256: e5c1bd4aaf71b1a43b3122be6d123edf60f1271508a0146e8fbe83a85b8c0cba
   category: main
   optional: false
 - name: libarrow-dataset
@@ -7146,10 +7146,10 @@ package:
     libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
     libparquet: 23.0.1
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-23.0.1-h91633f5_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-23.0.1-h91633f5_16_cpu.conda
   hash:
-    md5: 26d0a45325d26ededc9f0c3c1355818f
-    sha256: 4a5fc2ca4cdb5cf15aa990e07379c61922b1bb517ae0e423867411b91149c029
+    md5: f6a9950baa2ee5534ae4c6b0c392a4a7
+    sha256: 5dd7684e50bcd2cf066ec28ab423cadc47b45bd3e31ebed8ef5011d89426f521
   category: main
   optional: false
 - name: libarrow-dataset
@@ -7166,10 +7166,10 @@ package:
     libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
     libparquet: 23.0.1
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-23.0.1-ha4f4840_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-23.0.1-ha4f4840_16_cpu.conda
   hash:
-    md5: f9252ceb3f28fbd2e4e043e9ffabef10
-    sha256: 4ee00bcce703435c0cafa70120edb24e3cf38ab3d2a347e1bf85e8553756ce5c
+    md5: 42f5c8fceb85bb6d71170bae87702b4f
+    sha256: 55c4db227e40247e55592b6fd47c3b542602223c62a34d1f4c39fc7864151ada
   category: main
   optional: false
 - name: libarrow-dataset
@@ -7184,10 +7184,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-23.0.1-h7d8d6a5_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-23.0.1-h7d8d6a5_16_cpu.conda
   hash:
-    md5: 71f303904a9185c5e77043b5a4560e51
-    sha256: cb971eacc31909ceaac641fc31fb5855bf6b4bdc34241cf92fabac81e3304fb8
+    md5: d3f0028fcc47ca25ef1b52d6ffa13ffc
+    sha256: 079786c355b25f21e49c3ca3af891e613823823f14f3042968913b62dbc49778
   category: main
   optional: false
 - name: libarrow-substrait
@@ -7203,10 +7203,10 @@ package:
     libgcc: '>=14'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-23.0.1-hb4dd7c2_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-23.0.1-hb4dd7c2_16_cpu.conda
   hash:
-    md5: 89e8c1c684c607942a19b02973160644
-    sha256: 98bf9f4fa76b4b00bef6157101ee63f89ffb5f06e3c57e3ec509c76df7194b95
+    md5: d1de87f90bcf50cb00e747dd5b03820b
+    sha256: 61d9a9286cf8329605feabf05d2500e2904656b3c15bc2bcaf1f44638d7ac8ec
   category: main
   optional: false
 - name: libarrow-substrait
@@ -7221,10 +7221,10 @@ package:
     libarrow-dataset: 23.0.1
     libcxx: '>=21'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-23.0.1-h613493e_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-23.0.1-h613493e_16_cpu.conda
   hash:
-    md5: ea141fd345979a4d44544a7195ddd5ad
-    sha256: e9bac91ed0a020bab8cefa61df0d681a32373c9931358cfad613f0a8a2bc6992
+    md5: 304a07590259ca92c3cd389a49f4bded
+    sha256: 35b293467e3447aa48089a3fe4125f1480a00b8c4db5fc8a57634a5a476b7855
   category: main
   optional: false
 - name: libarrow-substrait
@@ -7239,10 +7239,10 @@ package:
     libarrow-dataset: 23.0.1
     libcxx: '>=21'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-23.0.1-h05be00f_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-23.0.1-h05be00f_16_cpu.conda
   hash:
-    md5: 3ab099b0006d33cc84f865a856d9171d
-    sha256: f5f9c44ed4eb5f6b8eda8f61c96c03e483e1f30b5248b7cb484903727687914c
+    md5: 8e8137ec067ac381885d6eb449573b12
+    sha256: e1629fd1cb4ab782c43664bdac076eeea51ce875f6b15f9f404bf82523e3e45a
   category: main
   optional: false
 - name: libarrow-substrait
@@ -7258,10 +7258,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-23.0.1-h524e9bd_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-23.0.1-h524e9bd_16_cpu.conda
   hash:
-    md5: 1f248058c12edc3de0366007efba65f6
-    sha256: e6222d972e7ffcc1f92582563ddcb00e377932b87bd8a839cc2062a109781547
+    md5: 8f14bde678c74a5d7dcd0ba232ba475f
+    sha256: cf2747c89b9bb175dde713efc543ea6517e66145c685b81fc7fd2716e1e4d92b
   category: main
   optional: false
 - name: libblas
@@ -7572,7 +7572,7 @@ package:
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -7582,16 +7582,16 @@ package:
     libnghttp2: '>=1.68.1,<2.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hcf29cc6_0.conda
   hash:
-    md5: c3cc2864f82a944bc90a7beb4d3b0e88
-    sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
+    md5: dcd79cabd5d435f48d75db3d81cb5874
+    sha256: 93ab25f02666eb8696fa70d9c920f2e3b370742ee17e2758705038a72e11147f
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -7600,16 +7600,16 @@ package:
     libnghttp2: '>=1.68.1,<2.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.20.0-h8f0b9e4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.21.0-h8f0b9e4_0.conda
   hash:
-    md5: 4a0085ccf90dc514f0fc0909a874045e
-    sha256: 5d3d8a82ca43347e96f1d79048921f3a7c25e32514bc7feb53ed2a040dcca54d
+    md5: ee12fea9cd972edf0bd63f10a95f38d9
+    sha256: fb5220bd8254be0d18c119c2a39ee19fb41b7355062b4b808b5bb95bb69f139f
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -7618,16 +7618,16 @@ package:
     libnghttp2: '>=1.68.1,<2.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.6,<4.0a0'
+    openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-hd5a2499_0.conda
   hash:
-    md5: 2f57b7d0c6adda88957586b7afd78438
-    sha256: 38c0bc634b61e542776e97cfd15d5d41edd304d4e47c333004d2d622439b2381
+    md5: 862eb5c81e1295f492fa261a68a4233f
+    sha256: 5f73f41b3504c9d41a60aa161f6c87c36f19f97c92b3510441db618e361dc946
   category: main
   optional: false
 - name: libcurl
-  version: 8.20.0
+  version: 8.21.0
   manager: conda
   platform: win-64
   dependencies:
@@ -7637,10 +7637,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.20.0-h8206538_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.21.0-h8206538_0.conda
   hash:
-    md5: 7bee27a8f0a295117ccb864f30d2d87e
-    sha256: f4ce5aa835a698532feaa368e804365a7e45a9edebe006a8e1c80505d893c24e
+    md5: ed32b5c68abfae7702a700b636c84a91
+    sha256: 384082b6f79454a89423f3e42ebba482719dac2221af33715970791d970c79b4
   category: main
   optional: false
 - name: libcxx
@@ -8271,7 +8271,7 @@ package:
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 3.5.0
+  version: 3.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -8283,15 +8283,15 @@ package:
     libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libstdcxx: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.6.0-h8d2ee43_0.conda
   hash:
-    md5: 8ae0593085ca8148fdbf0bc8f62e79c1
-    sha256: 42c8ca362013d0378ba58afb61940d23c94e0f7127004190dcd12fe4a3072953
+    md5: 50a88a9c7d89d854336c633966b67e56
+    sha256: eb6fe89a6e2ffa6b485c437022e15d2173c2da3ada86690cf250bcfe6f6382d5
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 3.5.0
+  version: 3.6.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -8302,15 +8302,15 @@ package:
     libgrpc: '>=1.78.1,<1.79.0a0'
     libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.5.0-h8b848e0_1.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.6.0-h8b848e0_0.conda
   hash:
-    md5: 323f0d14ccec33e69a6c16a11f3ec7c1
-    sha256: f6f23551b2f4b9c9b3e0c72398e4995702e832ee03b717e4d9802ce695f6938a
+    md5: 0617521fb705f0c4b6ad40352f1666d1
+    sha256: 93bc6400aaa20aad9de27c6f42f9c31dcddf8466ba9588c5bc4df644013267bf
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 3.5.0
+  version: 3.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -8321,15 +8321,15 @@ package:
     libgrpc: '>=1.78.1,<1.79.0a0'
     libopentelemetry-cpp: '>=1.27.0,<1.28.0a0'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.6.0-h688a705_0.conda
   hash:
-    md5: 3899a5a69da373a85e7f53be3d32b814
-    sha256: 20235ded7b8d125461a9ed5e02f174eae89e85a271d3343167015f779ebc4714
+    md5: be005bcbd77890a199ee583ba7a74bec
+    sha256: 650f0605bed3048ca69b547cc31e1d6c70b7371fb3212b00b103da6fd2f11d77
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 3.5.0
+  version: 3.6.0
   manager: conda
   platform: win-64
   dependencies:
@@ -8341,14 +8341,14 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-3.5.0-he22669a_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-3.6.0-he22669a_0.conda
   hash:
-    md5: 526136b0b872c2841e5947be047dadee
-    sha256: 3904d8f8a0bddc5b5baa534048c2633375b04337c14c3416c446bd6f667a5805
+    md5: 24239981d980d39030515bc50f696e2f
+    sha256: 11cb7ec822abcf6feedcd778f1f71d889b4c1b270949927aa468a6b24abe230d
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 3.5.0
+  version: 3.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -8357,18 +8357,18 @@ package:
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
     libgcc: '>=14'
-    libgoogle-cloud: 3.5.0
+    libgoogle-cloud: 3.6.0
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
     openssl: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.6.0-hdbdcf42_0.conda
   hash:
-    md5: 6f79d5f72cfcdd3509112233a8aedc2e
-    sha256: 6914f9b0f2d5bb0c5687b880c6c352a2333449d03ce80e6826230675062b57f1
+    md5: a5001567e3c2758834d63129ecb89bb1
+    sha256: 2d94ab8302408d34894024a80604e85936bb208a487841a222cafdb15c143f23
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 3.5.0
+  version: 3.6.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -8377,17 +8377,17 @@ package:
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
     libcxx: '>=19'
-    libgoogle-cloud: 3.5.0
+    libgoogle-cloud: 3.6.0
     libzlib: '>=1.3.2,<2.0a0'
     openssl: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-3.5.0-hea209c6_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-3.6.0-hea209c6_0.conda
   hash:
-    md5: 8c84b06d18a3c83c28eb89bca378daad
-    sha256: 086374067de8b3fd6198f87f8a7879d5042e35a7816e2a570155a3590e480a0d
+    md5: 3ab72a6e7f7c1b54e2ace239d06e9e7a
+    sha256: dc6272ad015a5d6a4cf4263ef11fd2d3889fdafbb9a049121aa6daaf7a165b4f
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 3.5.0
+  version: 3.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -8396,32 +8396,32 @@ package:
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
     libcxx: '>=19'
-    libgoogle-cloud: 3.5.0
+    libgoogle-cloud: 3.6.0
     libzlib: '>=1.3.2,<2.0a0'
     openssl: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.5.0-ha114238_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.6.0-ha114238_0.conda
   hash:
-    md5: ecc3983f92594b3863a7e5d47d1a71ba
-    sha256: 40b7074e3837fe3dcebef0e93f1f40fb995abd94787e51d231d31142e157dadd
+    md5: b7c9ec99242e620133106438ccfcf08e
+    sha256: a01821942ab88a433a81ec9a0e6aa72ed5f7ceb5e11a295f3eb28dd22a0a24bf
   category: main
   optional: false
 - name: libgoogle-cloud-storage
-  version: 3.5.0
+  version: 3.6.0
   manager: conda
   platform: win-64
   dependencies:
     libabseil: ''
     libcrc32c: '>=1.1.2,<1.2.0a0'
     libcurl: ''
-    libgoogle-cloud: 3.5.0
+    libgoogle-cloud: 3.6.0
     libzlib: '>=1.3.2,<2.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-3.5.0-he04ea4c_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-3.6.0-he04ea4c_0.conda
   hash:
-    md5: 7249500fac23f02b60b773878e4668b1
-    sha256: 90c9e66fc403ee42d1fb23dafb5873712bc89b103c22d963ebf932bce6cffefc
+    md5: 0f4a153aa13c9a98de0be992cfd9f6bb
+    sha256: 5c62334045397f97437f7cb2d44672914eb2facc12839aaac87386f2aeebd05b
   category: main
   optional: false
 - name: libgrpc
@@ -9004,10 +9004,10 @@ package:
     libstdcxx: '>=14'
     libthrift: '>=0.22.0,<0.22.1.0a0'
     openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-23.0.1-h7376487_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-23.0.1-h7376487_16_cpu.conda
   hash:
-    md5: a26f42d619bdcbb3b6ec5666a062c2fa
-    sha256: aa2a9989e79da6f85245696fbcaefd907618b23ab1d8d434f8a32ba60081300c
+    md5: 631a85d9f97cc5e9002734bcdf35f5dd
+    sha256: f200125318df02021ecda5e72e4628f731e6526a90d6d4df164376a2caa64489
   category: main
   optional: false
 - name: libparquet
@@ -9023,10 +9023,10 @@ package:
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libthrift: '>=0.22.0,<0.22.1.0a0'
     openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-23.0.1-h0f82bca_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-23.0.1-h0f82bca_16_cpu.conda
   hash:
-    md5: e3f9149bcbe79d8da6eeeb28d2b9c097
-    sha256: 7d60629291c888a965ee349e629581d8894dc771ae0c3363bf4638a6aa0d8acf
+    md5: d4cbdb7336d25817f849278d2885e9d0
+    sha256: e859028f900bc73ba5d38b06606cfddee1cda5d14622620fcc23a5fb0ca0eb6a
   category: main
   optional: false
 - name: libparquet
@@ -9042,10 +9042,10 @@ package:
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libthrift: '>=0.22.0,<0.22.1.0a0'
     openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-23.0.1-h840b369_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-23.0.1-h840b369_16_cpu.conda
   hash:
-    md5: 82e4f5452ffc0a39659b4801450d6170
-    sha256: 7ac88a729b43e407e958f045f69322636127f89dc3814852475707cbda580cef
+    md5: 866b3375cd6b0a47ed03f07a58669e71
+    sha256: 484b7a814d5682913929dd5d78fa7c9fc81586f3f65be7aeb1e7c638b76bb567
   category: main
   optional: false
 - name: libparquet
@@ -9059,10 +9059,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-23.0.1-h7051d1f_13_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-23.0.1-h7051d1f_16_cpu.conda
   hash:
-    md5: f351699cb1e1e509927091d78f99e003
-    sha256: 8f1e3d8eac43618fa09251207eb39d304fe2219c3a25f24d16ee5b4c9d2a2fc2
+    md5: 62b4fc5517e28bbdf3f2b549684947ca
+    sha256: ab58866d8330b2a367815cecf78090e380ab0113b57b6868a02c7818b8bd4c38
   category: main
   optional: false
 - name: libpng
@@ -9364,12 +9364,13 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-hf4e2dac_1.conda
   hash:
-    md5: 062b0ac602fb0adf250e3dfa86f221c4
-    sha256: 1ab603b6ec93933e76027e1f23b21b22b858ba1b56f1e1695ef6fe5e80cb7358
+    md5: f283e98005089bf29ac5774c2e209fbf
+    sha256: f2ad4d3abd4ed7a6a0d28c0ff153e27cb45c406814faa2570bc2581804283674
   category: main
   optional: false
 - name: libsqlite
@@ -9378,12 +9379,11 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.2-h8f8c405_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.2-h77d7759_1.conda
   hash:
-    md5: 4c019bd25570899d0f9755de01b89021
-    sha256: 4d4f3135d390d192ab9cdf3711d87e3be6bb7f3959c52a96e2f333b30960d6fb
+    md5: 7dd6b4bcbd437bba3358914e8598ecc0
+    sha256: d6cced99517569e8a71bd5d90859343e18def7a1fb18e224671b54dfb531b387
   category: main
   optional: false
 - name: libsqlite
@@ -9394,10 +9394,10 @@ package:
     __osx: '>=11.0'
     icu: '>=78.3,<79.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_1.conda
   hash:
-    md5: 1ebde5c677f00765233a17e278571177
-    sha256: 862463917e8ef5ac3ebdaf8f19914634b457609cc27ba678b7197124cefeb1f7
+    md5: 2749be4dc52f3a6699e9dea29b78410a
+    sha256: f3b0289e03883f5ac3d646c318fefebc77f25897f2200459658f4273f901df45
   category: main
   optional: false
 - name: libsqlite
@@ -9408,10 +9408,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.2-hf5d6505_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.2-hf5d6505_1.conda
   hash:
-    md5: df294e7f9f24a6063f0e226f4d028fda
-    sha256: 4cd81319dcc58fb758da20a6d5595950c021adc2c18d7cffeadcfb590529629f
+    md5: b510cd61047daf53a68be8daeb56b426
+    sha256: a643cbc7593b443967093afb14bb892b94094e9135e30772fd1a9dfda8bb08b6
   category: main
   optional: false
 - name: libssh2
@@ -11418,7 +11418,7 @@ package:
   category: main
   optional: false
 - name: msgpack-python
-  version: 1.2.0
+  version: 1.2.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -11427,14 +11427,14 @@ package:
     libstdcxx: '>=14'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.0-py311hdf67eae_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py311hdf67eae_0.conda
   hash:
-    md5: f801b293c221d5d56c7e6afe0871465e
-    sha256: 86bc5946308c7ef1b8dab5b6cf8fc4fbd3482b166abc4037c70754234f57ee72
+    md5: edbfdea2063003c565d19b7f3743811e
+    sha256: 14cd416f5db9837557806e6fb25f1a0a100c1b906cd02bdfaeda3e0a65ce1ae9
   category: main
   optional: false
 - name: msgpack-python
-  version: 1.2.0
+  version: 1.2.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -11442,14 +11442,14 @@ package:
     libcxx: '>=19'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.2.0-py312hdb80668_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/msgpack-python-1.2.1-py312hdb80668_0.conda
   hash:
-    md5: d152189d4ee58fa25bca512a96bce37f
-    sha256: 191487b8f422cd610a577f6ec3f4d127b26043336f38c9ffc8217e34118eaae3
+    md5: 13f98c8be22877a6b44985c9018957e6
+    sha256: 335f71b49d612985440f4442e4c95a74397b86f462cfb8b56b43f53044aaff29
   category: main
   optional: false
 - name: msgpack-python
-  version: 1.2.0
+  version: 1.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -11457,14 +11457,14 @@ package:
     libcxx: '>=19'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.2.0-py312h766f71e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.2.1-py312h766f71e_0.conda
   hash:
-    md5: 135caacbdc87ea276cdc4e37666edb7e
-    sha256: eecce72621c540487698c64dec2b6cdaad09ea74d73a4b817857f2ed6f19b2a4
+    md5: 86d034fc6116be109bbbbe9079ac73f8
+    sha256: 342a8d6976c198d741844d51268beaffd5dec56a2b688b9350dbf9f4fa1004f9
   category: main
   optional: false
 - name: msgpack-python
-  version: 1.2.0
+  version: 1.2.1
   manager: conda
   platform: win-64
   dependencies:
@@ -11473,10 +11473,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.2.0-py312hf90b1b7_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.2.1-py312hf90b1b7_0.conda
   hash:
-    md5: 39976dfa176ff03e1cd55f493c311899
-    sha256: 025797912d97f871cc22ad876ec75e18dc444c96fda0b7dedefc97804369a8a8
+    md5: 7be9af13377c126be5c6a2fd28af9b6c
+    sha256: 706651825726865f4b93f8437507da94b5d7060476a3be09d33d8d4176aef886
   category: main
   optional: false
 - name: multidict
@@ -11977,7 +11977,7 @@ package:
   category: main
   optional: false
 - name: numpy
-  version: 2.4.6
+  version: 2.5.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -11988,14 +11988,14 @@ package:
     liblapack: '>=3.9.0,<4.0a0'
     python: ''
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.6-py312h746d82c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.5.0-py312h746d82c_0.conda
   hash:
-    md5: 86c91d10224283ed367225057a09e4a3
-    sha256: e7837f62b874c987c1bd2eda335ae9b977caf61a5227c23e4e8cceef88bb21b6
+    md5: d809cfbabdf460279c6b1661c88ebed5
+    sha256: 6f7429d4aca21e89d1fe7c588a043ffdf06f65e4c8e4237a2d0f3751f749154b
   category: main
   optional: false
 - name: numpy
-  version: 2.4.6
+  version: 2.5.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12006,14 +12006,14 @@ package:
     liblapack: '>=3.9.0,<4.0a0'
     python: ''
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.6-py312ha003a3f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py312ha003a3f_0.conda
   hash:
-    md5: 9f554fdfa902971390975b489e678c03
-    sha256: b09e03dace335a6f303352fc4e167243e04d7026d55008546fa643d224fb0bad
+    md5: f223ea9a1ca019ddbcfe28ce02ec366c
+    sha256: 36f7062ce484ce45b8fdb2ee48cbbc7c0023004ba01e692efd5cd70034d93609
   category: main
   optional: false
 - name: numpy
-  version: 2.4.6
+  version: 2.5.0
   manager: conda
   platform: win-64
   dependencies:
@@ -12025,10 +12025,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.6-py312ha3f287d_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.5.0-py312ha3f287d_0.conda
   hash:
-    md5: 1dd6f497cc8369359f024463426e323c
-    sha256: 9abf760418f2497f87715fa35d1c9cea5416be9edd1b166a218dfabe3b16e5be
+    md5: 2d395ffbe339689fb2b0a4b051960ec9
+    sha256: 995e108a43e85fd3cbd17f76e3ecc04a7ee5537bc242190e1c5e227867d9db03
   category: main
   optional: false
 - name: numpyro
@@ -12319,55 +12319,55 @@ package:
   category: main
   optional: false
 - name: opentelemetry-proto
-  version: 1.42.1
+  version: 1.43.0
   manager: conda
   platform: linux-64
   dependencies:
-    protobuf: <7.0,>=5.0
+    protobuf: <8.0,>=5.0
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.42.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.43.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ba2190ce0c24aa9fe90384b0de02d94
-    sha256: b96519080afd56814ebd255543e32df3084af86ecf4021e19aa833790e74a1f8
+    md5: 188527786acf4c10fd59d0335f809b8b
+    sha256: 2fc0b41f9f479c5b7fd307074c31c007bcd32b7ba10adee0462dda6a4d4fffa0
   category: main
   optional: false
 - name: opentelemetry-proto
-  version: 1.42.1
+  version: 1.43.0
   manager: conda
   platform: osx-64
   dependencies:
-    protobuf: <7.0,>=5.0
+    protobuf: <8.0,>=5.0
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.42.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.43.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ba2190ce0c24aa9fe90384b0de02d94
-    sha256: b96519080afd56814ebd255543e32df3084af86ecf4021e19aa833790e74a1f8
+    md5: 188527786acf4c10fd59d0335f809b8b
+    sha256: 2fc0b41f9f479c5b7fd307074c31c007bcd32b7ba10adee0462dda6a4d4fffa0
   category: main
   optional: false
 - name: opentelemetry-proto
-  version: 1.42.1
+  version: 1.43.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    protobuf: <7.0,>=5.0
+    protobuf: <8.0,>=5.0
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.42.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.43.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ba2190ce0c24aa9fe90384b0de02d94
-    sha256: b96519080afd56814ebd255543e32df3084af86ecf4021e19aa833790e74a1f8
+    md5: 188527786acf4c10fd59d0335f809b8b
+    sha256: 2fc0b41f9f479c5b7fd307074c31c007bcd32b7ba10adee0462dda6a4d4fffa0
   category: main
   optional: false
 - name: opentelemetry-proto
-  version: 1.42.1
+  version: 1.43.0
   manager: conda
   platform: win-64
   dependencies:
-    protobuf: <7.0,>=5.0
+    protobuf: <8.0,>=5.0
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.42.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.43.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ba2190ce0c24aa9fe90384b0de02d94
-    sha256: b96519080afd56814ebd255543e32df3084af86ecf4021e19aa833790e74a1f8
+    md5: 188527786acf4c10fd59d0335f809b8b
+    sha256: 2fc0b41f9f479c5b7fd307074c31c007bcd32b7ba10adee0462dda6a4d4fffa0
   category: main
   optional: false
 - name: opentelemetry-sdk
@@ -13309,55 +13309,55 @@ package:
   category: main
   optional: false
 - name: prettytable
-  version: 3.17.0
+  version: 3.18.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-    wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.17.0-pyhd8ed1ab_0.conda
+    wcwidth: '>=0.3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.18.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 9a12c482f559d39f3ed9550ba9e0eeb0
-    sha256: a1cc667bd683f26c319ccab257cd3e17b33f34ef90ff4f548a811a342358c952
+    md5: 5bfa6d6ff0b4dbff82268ddc83626cee
+    sha256: de4bea093492d7dbb13997aa804ced847588bff59c88db1b3581b75e0e81f2c3
   category: main
   optional: false
 - name: prettytable
-  version: 3.17.0
+  version: 3.18.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-    wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.17.0-pyhd8ed1ab_0.conda
+    wcwidth: '>=0.3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.18.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 9a12c482f559d39f3ed9550ba9e0eeb0
-    sha256: a1cc667bd683f26c319ccab257cd3e17b33f34ef90ff4f548a811a342358c952
+    md5: 5bfa6d6ff0b4dbff82268ddc83626cee
+    sha256: de4bea093492d7dbb13997aa804ced847588bff59c88db1b3581b75e0e81f2c3
   category: main
   optional: false
 - name: prettytable
-  version: 3.17.0
+  version: 3.18.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-    wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.17.0-pyhd8ed1ab_0.conda
+    wcwidth: '>=0.3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.18.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 9a12c482f559d39f3ed9550ba9e0eeb0
-    sha256: a1cc667bd683f26c319ccab257cd3e17b33f34ef90ff4f548a811a342358c952
+    md5: 5bfa6d6ff0b4dbff82268ddc83626cee
+    sha256: de4bea093492d7dbb13997aa804ced847588bff59c88db1b3581b75e0e81f2c3
   category: main
   optional: false
 - name: prettytable
-  version: 3.17.0
+  version: 3.18.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.10'
-    wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.17.0-pyhd8ed1ab_0.conda
+    wcwidth: '>=0.3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.18.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 9a12c482f559d39f3ed9550ba9e0eeb0
-    sha256: a1cc667bd683f26c319ccab257cd3e17b33f34ef90ff4f548a811a342358c952
+    md5: 5bfa6d6ff0b4dbff82268ddc83626cee
+    sha256: de4bea093492d7dbb13997aa804ced847588bff59c88db1b3581b75e0e81f2c3
   category: main
   optional: false
 - name: prometheus-cpp
@@ -14330,7 +14330,7 @@ package:
   category: main
   optional: false
 - name: pydantic-settings
-  version: 2.14.1
+  version: 2.14.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -14338,14 +14338,14 @@ package:
     python: ''
     python-dotenv: '>=0.21.0'
     typing-inspection: '>=0.4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
   hash:
-    md5: 3b05fc4bb3e31efd3498136b3221c18f
-    sha256: a4ad48b01e5e2640561011d8d48ac038fec66670f24e22c370097747bd9200d2
+    md5: a1c5305893d9956abd2079d377c5113f
+    sha256: de1eb2cdb22a678387ec7757f10b7815c4c2a4d62f23b2a70fe4beff7e8a1fd4
   category: main
   optional: false
 - name: pydantic-settings
-  version: 2.14.1
+  version: 2.14.2
   manager: conda
   platform: osx-64
   dependencies:
@@ -14353,14 +14353,14 @@ package:
     python: '>=3.10'
     python-dotenv: '>=0.21.0'
     typing-inspection: '>=0.4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
   hash:
-    md5: 3b05fc4bb3e31efd3498136b3221c18f
-    sha256: a4ad48b01e5e2640561011d8d48ac038fec66670f24e22c370097747bd9200d2
+    md5: a1c5305893d9956abd2079d377c5113f
+    sha256: de1eb2cdb22a678387ec7757f10b7815c4c2a4d62f23b2a70fe4beff7e8a1fd4
   category: main
   optional: false
 - name: pydantic-settings
-  version: 2.14.1
+  version: 2.14.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -14368,14 +14368,14 @@ package:
     python: '>=3.10'
     python-dotenv: '>=0.21.0'
     typing-inspection: '>=0.4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
   hash:
-    md5: 3b05fc4bb3e31efd3498136b3221c18f
-    sha256: a4ad48b01e5e2640561011d8d48ac038fec66670f24e22c370097747bd9200d2
+    md5: a1c5305893d9956abd2079d377c5113f
+    sha256: de1eb2cdb22a678387ec7757f10b7815c4c2a4d62f23b2a70fe4beff7e8a1fd4
   category: main
   optional: false
 - name: pydantic-settings
-  version: 2.14.1
+  version: 2.14.2
   manager: conda
   platform: win-64
   dependencies:
@@ -14383,10 +14383,10 @@ package:
     python: '>=3.10'
     python-dotenv: '>=0.21.0'
     typing-inspection: '>=0.4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
   hash:
-    md5: 3b05fc4bb3e31efd3498136b3221c18f
-    sha256: a4ad48b01e5e2640561011d8d48ac038fec66670f24e22c370097747bd9200d2
+    md5: a1c5305893d9956abd2079d377c5113f
+    sha256: de1eb2cdb22a678387ec7757f10b7815c4c2a4d62f23b2a70fe4beff7e8a1fd4
   category: main
   optional: false
 - name: pygments
@@ -16223,7 +16223,7 @@ package:
   category: main
   optional: false
 - name: scipy
-  version: 1.17.1
+  version: 1.18.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -16234,17 +16234,17 @@ package:
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     liblapack: '>=3.9.0,<4.0a0'
-    numpy: '>=1.25.2'
+    numpy: '>=2.0.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.17.1-py312h6309490_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.18.0-py312h6309490_0.conda
   hash:
-    md5: 284f71322e48e8ae8ce23d48356df042
-    sha256: 4b3663a4f1a92c881ba0fc4d317eee04831adc44400d85bac5b27c503445f6ad
+    md5: 7c6973eecefc02ccdbaa35fca709ff71
+    sha256: 8a719faf17424d6ef4d52eaf3086278c70c8ac63b6a2bf378d781eab68a2f2d2
   category: main
   optional: false
 - name: scipy
-  version: 1.17.1
+  version: 1.18.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -16255,33 +16255,33 @@ package:
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     liblapack: '>=3.9.0,<4.0a0'
-    numpy: '>=1.25.2'
+    numpy: '>=2.0.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py312h4519d97_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py312h4519d97_0.conda
   hash:
-    md5: 173d5eeba324363d9171946e86a81687
-    sha256: c0ed2cbfa3485bac8570e52b577475778c603ee92d078a8b164d1ddec992e577
+    md5: 5a352ca7e4f49ca6585dd30a4812bd20
+    sha256: 708f27ae8ccf62cf714dc5c6f728ae733dc14315c842e935ed7f491d214df2b0
   category: main
   optional: false
 - name: scipy
-  version: 1.17.1
+  version: 1.18.0
   manager: conda
   platform: win-64
   dependencies:
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
     liblapack: '>=3.9.0,<4.0a0'
-    numpy: '>=1.25.2'
+    numpy: '>=2.0.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.17.1-py312h9b3c559_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.18.0-py312h9b3c559_0.conda
   hash:
-    md5: 0b8c96ed1c04732ff8eb5d481b44c43c
-    sha256: b8a13caeb04f2b943e7c617a4b76805450618716b38688ee8d3f79b60d529e84
+    md5: e1fee578f6c533ff532693143919afde
+    sha256: 68e7c49be1e409ed2ac44f2977581d58a9a4d12e6724a4a5c5470348e5e40f34
   category: main
   optional: false
 - name: setuptools
@@ -18781,7 +18781,7 @@ package:
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -18789,42 +18789,42 @@ package:
     libgcc: '>=14'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.1-py311h49ec1c0_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py311h49ec1c0_0.conda
   hash:
-    md5: e6cc7808fc5ac070f75c682ca9d00cb5
-    sha256: 4461bb07b3aed91fcfb437891a53a0fa0c2591910bc5da85abce481694effced
+    md5: ebf29957ecd2619000dd136b80bf5933
+    sha256: 12dbcbf5416c05f2fae8e13839a6c811342249dfb736c91b8ebcad5370ec03c8
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-2.2.1-py312h933eb07_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-2.2.2-py312h933eb07_0.conda
   hash:
-    md5: 9832454120b29950e9304a608d71c01a
-    sha256: d836266c79039b60e2104d87d277a74ddc95b195c84ed08dc31185faf3dead6c
+    md5: 2d76dc42a4d65ce7c1cdaaa4601d42a6
+    sha256: a9954c9e5772d9bb3bcdbf0f1018b023830c3c8830a3ccd4d38999dac9fc1f9d
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.1-py312h2bbb03f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.2-py312h2bbb03f_0.conda
   hash:
-    md5: a82ae4e18607e068c9259136d07e4f87
-    sha256: baefb9a73519863a70f6e7a6f6acb982ee5485ae986a16960ff1e8cb99f1a023
+    md5: f7115a8060360996f419b397727293ab
+    sha256: 0ea6de1d6b8bc70b0fae3856e1e8c99c15f0fa5bb9863282b90f2da63ffcc953
   category: main
   optional: false
 - name: wrapt
-  version: 2.2.1
+  version: 2.2.2
   manager: conda
   platform: win-64
   dependencies:
@@ -18833,10 +18833,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-2.2.1-py312he06e257_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-2.2.2-py312he06e257_0.conda
   hash:
-    md5: 1f8d2f7e4468f75b510c98310e5a9a8e
-    sha256: 81ac3d1b792ace6ef6994a87cc374459d946479fac122f7d57251727d39a0795
+    md5: 573f686209e82c06daef1e43ee79975f
+    sha256: 8fa16daca416ab83f64b8731c33a6f211f4e703f02d03c7eabda45a6a3320657
   category: main
   optional: false
 - name: wslink
@@ -19555,6 +19555,58 @@ package:
     sha256: 3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f
   category: main
   optional: false
+- name: globus-sdk
+  version: 4.8.1
+  manager: pip
+  platform: linux-64
+  dependencies:
+    cryptography: '>=3.3.1,<3.4.0 || >3.4.0'
+    pyjwt: '>=2.0.0,<3.0.0'
+    requests: '>=2.19.1,<3.0.0'
+  url: https://files.pythonhosted.org/packages/30/bb/2b865d79c5bdc574b428e5502a24e7517cdaeca2569f6baa051106f9fa7e/globus_sdk-4.8.1-py3-none-any.whl
+  hash:
+    sha256: 48b57862902a26d8606e73374c354415724cfa9d99301af7e9e406659dafe78d
+  category: main
+  optional: false
+- name: globus-sdk
+  version: 4.8.1
+  manager: pip
+  platform: osx-64
+  dependencies:
+    cryptography: '>=3.3.1,<3.4.0 || >3.4.0'
+    pyjwt: '>=2.0.0,<3.0.0'
+    requests: '>=2.19.1,<3.0.0'
+  url: https://files.pythonhosted.org/packages/30/bb/2b865d79c5bdc574b428e5502a24e7517cdaeca2569f6baa051106f9fa7e/globus_sdk-4.8.1-py3-none-any.whl
+  hash:
+    sha256: 48b57862902a26d8606e73374c354415724cfa9d99301af7e9e406659dafe78d
+  category: main
+  optional: false
+- name: globus-sdk
+  version: 4.8.1
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    cryptography: '>=3.3.1,<3.4.0 || >3.4.0'
+    pyjwt: '>=2.0.0,<3.0.0'
+    requests: '>=2.19.1,<3.0.0'
+  url: https://files.pythonhosted.org/packages/30/bb/2b865d79c5bdc574b428e5502a24e7517cdaeca2569f6baa051106f9fa7e/globus_sdk-4.8.1-py3-none-any.whl
+  hash:
+    sha256: 48b57862902a26d8606e73374c354415724cfa9d99301af7e9e406659dafe78d
+  category: main
+  optional: false
+- name: globus-sdk
+  version: 4.8.1
+  manager: pip
+  platform: win-64
+  dependencies:
+    cryptography: '>=3.3.1,<3.4.0 || >3.4.0'
+    pyjwt: '>=2.0.0,<3.0.0'
+    requests: '>=2.19.1,<3.0.0'
+  url: https://files.pythonhosted.org/packages/30/bb/2b865d79c5bdc574b428e5502a24e7517cdaeca2569f6baa051106f9fa7e/globus_sdk-4.8.1-py3-none-any.whl
+  hash:
+    sha256: 48b57862902a26d8606e73374c354415724cfa9d99301af7e9e406659dafe78d
+  category: main
+  optional: false
 - name: iri-api-autogen
   version: 0.1.2
   manager: pip
@@ -19649,6 +19701,50 @@ package:
   url: https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl
   hash:
     sha256: b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164
+  category: main
+  optional: false
+- name: pyjwt
+  version: 2.13.0
+  manager: pip
+  platform: linux-64
+  dependencies:
+    cryptography: '>=3.4.0'
+  url: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+  hash:
+    sha256: 66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728
+  category: main
+  optional: false
+- name: pyjwt
+  version: 2.13.0
+  manager: pip
+  platform: osx-64
+  dependencies:
+    cryptography: '>=3.4.0'
+  url: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+  hash:
+    sha256: 66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728
+  category: main
+  optional: false
+- name: pyjwt
+  version: 2.13.0
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    cryptography: '>=3.4.0'
+  url: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+  hash:
+    sha256: 66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728
+  category: main
+  optional: false
+- name: pyjwt
+  version: 2.13.0
+  manager: pip
+  platform: win-64
+  dependencies:
+    cryptography: '>=3.4.0'
+  url: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+  hash:
+    sha256: 66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728
   category: main
   optional: false
 - name: sfapi-client

--- a/dashboard/environment.yml
+++ b/dashboard/environment.yml
@@ -29,5 +29,6 @@ dependencies:
   - trame-router
   - trame-vuetify
   - pip:
-    - sfapi_client
     - amsc-client
+    - globus-sdk
+    - sfapi_client


### PR DESCRIPTION
## Overview

Add `globus-sdk` through `pip` to the dashboard conda environment, needed for Globus authentication when we use AmSC IRI API.

## Notes

AmSC Python client's own error message points to a different solution,

```
amsc_client.core.exceptions.AuthenticationError: globus-sdk is required for Globus authentication. Install it with: pip install amsc-client[globus]
```

which, however, does not seem to work and hence was not included in #456. It did seem to work in #439 and I'm not clear about what changed between then and now.